### PR TITLE
Improve plain text and HTML conversion in WordEditor

### DIFF
--- a/src/components/WordEditor/WordEditor.tsx
+++ b/src/components/WordEditor/WordEditor.tsx
@@ -233,7 +233,16 @@ export const WordEditor = forwardRef<WordEditorHandle, WordEditorProps>(
         // For plain text files, wrap in paragraph tags; for HTML, use as-is
         let htmlContent: string;
         if (filePath.endsWith('.txt')) {
-          htmlContent = `<p>${fileContent.replace(/\n/g, '</p><p>')}</p>`;
+          // Split by newlines and create paragraphs, handling empty lines correctly
+          // Trim trailing newlines to prevent empty paragraphs at the end
+          const trimmedContent = fileContent.replace(/\n+$/, '');
+          if (trimmedContent === '') {
+            htmlContent = '<p></p>';
+          } else {
+            // Split by newlines and wrap each line (including empty ones) in paragraph tags
+            const lines = trimmedContent.split('\n');
+            htmlContent = lines.map(line => `<p>${line}</p>`).join('');
+          }
         } else {
           htmlContent = fileContent;
         }


### PR DESCRIPTION
Refines the logic for converting between plain text and HTML in LexicalEditor and WordEditor. Ensures that empty lines are preserved as empty paragraphs, trailing newlines are normalized, and text extraction from HTML is robust, preventing accumulation of extra newlines on save/reload cycles.