### PR TITLE
Update contribution workflow and code signing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,13 @@ Before you begin, ensure you have the following installed:
 
 ### Development Workflow
 
-1. **Create a feature branch**
+1. **Checkout the dev branch** (feature branches should be created from `dev`)
+   ```bash
+   git checkout dev
+   git pull origin dev
+   ```
+
+2. **Create a feature branch**
    ```bash
    git checkout -b feature/your-feature-name
    ```
@@ -50,7 +56,7 @@ Before you begin, ensure you have the following installed:
    git checkout -b fix/your-bug-fix
    ```
 
-2. **Run the development server**
+3. **Run the development server**
    ```bash
    npm run electron:dev
    ```
@@ -59,12 +65,12 @@ Before you begin, ensure you have the following installed:
    - Start the Vite dev server
    - Launch the Electron application
 
-3. **Make your changes**
+4. **Make your changes**
    - Edit files in `src/` for React components
    - Edit files in `electron/` for main process code
    - The app will hot-reload automatically
 
-4. **Run tests**
+5. **Run tests**
    ```bash
    # Run all tests
    npm run test
@@ -79,12 +85,12 @@ Before you begin, ensure you have the following installed:
    npm run test:coverage
    ```
 
-5. **Check code quality**
+6. **Check code quality**
    ```bash
    npm run lint
    ```
 
-6. **Build for production** (optional, to verify build works)
+7. **Build for production** (optional, to verify build works)
    ```bash
    npm run build:all
    ```

--- a/docs/CODE_SIGNING_FIX.md
+++ b/docs/CODE_SIGNING_FIX.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Applied the working code signing configuration from the VidCap app to fix code signing issues in PDFtract. The solution disables code signing completely and prevents electron-builder from attempting to download/extract the winCodeSign archive that causes symlink permission errors on Windows.
+Applied the working code signing configuration from the VidCap app to fix code signing issues in The Vault. The solution disables code signing completely and prevents electron-builder from attempting to download/extract the winCodeSign archive that causes symlink permission errors on Windows.
 
 ## Changes Made
 


### PR DESCRIPTION
Improved CONTRIBUTING.md by clarifying feature branch creation from the dev branch and renumbering workflow steps. Updated CODE_SIGNING_FIX.md to reference 'The Vault' instead of 'PDFtract' for code signing configuration context.