### PR TITLE
Update TypeScript config for electron and declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,8 @@
     },
     "types": ["node", "vite/client"]
   },
-  "include": ["src", "electron"],
-  "exclude": ["src/test-utils", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+  "include": ["src"],
+  "exclude": ["src/test-utils", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "electron/**/*"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -10,7 +10,10 @@
     "outDir": "dist-electron",
     "rootDir": ".",
     "target": "ES2020",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["vite.config.ts", "electron/**/*"],
   "exclude": ["electron/**/__tests__/**/*", "electron/**/*.test.ts"]


### PR DESCRIPTION
Restrict main tsconfig to 'src' and exclude 'electron' directory. Update node tsconfig to enable declaration file generation and declaration maps, and set 'noEmit' to false for proper output.