### PR TITLE
Update CI to support native module builds on Windows

### DIFF
--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -23,8 +23,19 @@ jobs:
           node-version: "20"
           cache: "npm"
 
+      - name: Setup Python (for node-gyp)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Windows Build Tools
+        uses: microsoft/setup-msbuild@v1
+
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-optional
+        env:
+          # Configure for Electron native module builds
+          npm_config_msvs_version: "2022"
 
       - name: Build Electron app
         run: npm run electron:build


### PR DESCRIPTION
Adds Python and MSBuild setup steps to the prerelease-build workflow to support Electron native module builds on Windows. Also updates npm install to use --no-optional and sets npm_config_msvs_version to 2022 for compatibility.