### PR TITLE
56 create a CICD pipline for the prerelease

### DIFF
--- a/.cursor/plans/github_actions_prerelease_workflow_c905f8d3.plan.md
+++ b/.cursor/plans/github_actions_prerelease_workflow_c905f8d3.plan.md
@@ -4,18 +4,18 @@ overview: Create a GitHub Actions workflow that triggers on merge to a branch, b
 todos:
   - id: create-workflow-dir
     content: Create .github/workflows directory structure
-    status: pending
+    status: completed
   - id: create-version-script
     content: Create scripts/update-version.py to handle automatic versioning with git commit hash
-    status: pending
+    status: completed
   - id: create-workflow-file
     content: Create .github/workflows/prerelease-build.yml with build steps, version update, and release creation
-    status: pending
+    status: completed
     dependencies:
       - create-version-script
   - id: test-workflow
     content: Test workflow on current branch to verify build and release creation works
-    status: pending
+    status: completed
     dependencies:
       - create-workflow-file
 ---
@@ -114,7 +114,7 @@ The existing configuration already disables signing:
 
 The workflow will execute:
 
-```bash
+````bash
 npm ci
 python scripts/update-version.py
 npm run electron:build
@@ -145,4 +145,5 @@ The `electron:build` script already:
 ## Notes
 
 - No code signing certificates needed (already configured)
-- Windows-only build (as requested)
+
+````

--- a/.cursor/plans/github_actions_prerelease_workflow_c905f8d3.plan.md
+++ b/.cursor/plans/github_actions_prerelease_workflow_c905f8d3.plan.md
@@ -1,0 +1,148 @@
+---
+name: GitHub Actions Prerelease Workflow
+overview: Create a GitHub Actions workflow that triggers on merge to a branch, builds the Electron Windows installer without code signing, auto-versions using git commit hash, and creates a GitHub Release with the installer artifact.
+todos:
+  - id: create-workflow-dir
+    content: Create .github/workflows directory structure
+    status: pending
+  - id: create-version-script
+    content: Create scripts/update-version.py to handle automatic versioning with git commit hash
+    status: pending
+  - id: create-workflow-file
+    content: Create .github/workflows/prerelease-build.yml with build steps, version update, and release creation
+    status: pending
+    dependencies:
+      - create-version-script
+  - id: test-workflow
+    content: Test workflow on current branch to verify build and release creation works
+    status: pending
+    dependencies:
+      - create-workflow-file
+---
+
+# GitHub
+
+Actions Prerelease Build Workflow
+
+## Overview
+
+Create a GitHub Actions workflow that automatically builds the Electron Windows installer and creates a prerelease when code is merged into a branch. The workflow will use automatic versioning based on git commit hash and skip code signing.
+
+## Implementation Details
+
+### 1. Workflow File Structure
+
+- Create `.github/workflows/prerelease-build.yml`
+- Trigger on `push` to the current branch (for testing)
+- Later can be changed to trigger on merge to `prerelease` branch
+
+### 2. Workflow Steps
+
+The workflow will:
+
+1. **Checkout code** - Get the latest code from the repository
+2. **Setup Node.js** - Install Node.js 20.x (matching package.json requirements)
+3. **Install dependencies** - Run `npm ci` for reproducible builds
+4. **Auto-version** - Update `package.json` version with git commit hash suffix
+
+- Format: `1.0.0-prerelease.X-{short-commit-hash}`
+- Use Python script or Node.js to update version
+
+5. **Build Electron app** - Run `npm run electron:build`
+
+- This already handles code signing disable via `scripts/electron-build.mjs`
+- Builds Windows NSIS installer to `release/` directory
+
+6. **Create GitHub Release** - Use GitHub API to create a prerelease
+
+- Tag format: `v{version}` (e.g., `v1.0.0-prerelease.4-abc1234`)
+- Release name: `Prerelease {version}`
+- Upload installer artifact: `Vault Setup {version}.exe`
+
+7. **Upload artifacts** - Also upload build artifacts as workflow artifacts
+
+### 3. Version Management Script
+
+Create a Python script `scripts/update-version.py` to:
+
+- Read current version from `package.json`
+- Extract base version (e.g., `1.0.0-prerelease.4`)
+- Get short git commit hash
+- Append commit hash: `1.0.0-prerelease.4-abc1234`
+- Update `package.json` with new version
+- Return new version for use in workflow
+
+### 4. Code Signing Configuration
+
+The existing configuration already disables signing:
+
+- `electron-builder.json` has `"sign": null` for Windows
+- `scripts/electron-build.mjs` sets `CSC_IDENTITY_AUTO_DISCOVERY=false`
+- Workflow will ensure these settings are respected
+
+### 5. Files to Create/Modify
+
+**New Files:**
+
+- `.github/workflows/prerelease-build.yml` - Main workflow file
+- `scripts/update-version.py` - Version update script
+
+**Existing Files (no changes needed):**
+
+- `package.json` - Already has build scripts
+- `electron-builder.json` - Already configured for no signing
+- `scripts/electron-build.mjs` - Already handles signing disable
+
+### 6. Workflow Configuration
+
+**Triggers:**
+
+- Initially: `on: push: branches: [current-branch]` (for testing)
+- Later: Change to `on: push: branches: [prerelease]`
+
+**Environment Variables:**
+
+- `CSC_IDENTITY_AUTO_DISCOVERY=false` - Disable code signing
+- `SKIP_NOTARIZATION=true` - Skip macOS notarization (if needed)
+
+**Permissions:**
+
+- `contents: write` - To create releases and tags
+- `actions: read` - Standard permissions
+
+### 7. Build Process
+
+The workflow will execute:
+
+```bash
+npm ci
+python scripts/update-version.py
+npm run electron:build
+```
+
+The `electron:build` script already:
+
+- Cleans release directory
+- Builds frontend and Electron main process
+- Runs electron-builder with signing disabled
+
+### 8. Release Creation
+
+- Use `gh` CLI or GitHub API to create release
+- Tag: `v{version}`
+- Prerelease: `true`
+- Upload: `release/Vault Setup {version}.exe`
+- Release notes: Auto-generated from commit messages or simple template
+
+## Testing Strategy
+
+1. Test workflow on current branch first
+2. Verify installer is created correctly
+3. Verify version includes commit hash
+4. Verify GitHub Release is created
+5. Once confirmed, change trigger to `prerelease` branch
+
+## Notes
+
+- No code signing certificates needed (already configured)
+- Windows-only build (as requested)

--- a/.cursor/plans/github_actions_prerelease_workflow_c905f8d3.plan.md
+++ b/.cursor/plans/github_actions_prerelease_workflow_c905f8d3.plan.md
@@ -146,4 +146,5 @@ The `electron:build` script already:
 
 - No code signing certificates needed (already configured)
 
+
 ````

--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -1,0 +1,93 @@
+name: Prerelease Build
+
+on:
+  push:
+    branches:
+      - 56-create-a-cicd-pipline-for-the-prerelease  # Change to 'prerelease' after testing
+
+permissions:
+  contents: write  # Required to create releases and tags
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for git commit hash
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Update version with commit hash
+        id: version
+        run: |
+          python scripts/update-version.py
+          # Read the updated version from package.json
+          $version = (Get-Content package.json | ConvertFrom-Json).version
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+          echo "Version set to: $version"
+
+      - name: Build Electron app
+        run: npm run electron:build
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+          SKIP_NOTARIZATION: 'true'
+
+      - name: Find installer
+        id: find-installer
+        run: |
+          $installer = Get-ChildItem -Path release -Filter "*.exe" | Select-Object -First 1
+          if ($installer) {
+            echo "installer_path=$($installer.FullName)" >> $env:GITHUB_OUTPUT
+            echo "installer_name=$($installer.Name)" >> $env:GITHUB_OUTPUT
+            echo "Found installer: $($installer.Name)"
+          } else {
+            Write-Error "No installer found in release directory"
+            exit 1
+          }
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Prerelease ${{ steps.version.outputs.version }}
+          body: |
+            ## Prerelease Build
+            
+            **Version:** ${{ steps.version.outputs.version }}
+            **Commit:** ${{ github.sha }}
+            **Branch:** ${{ github.ref_name }}
+            
+            This is an automated prerelease build.
+            
+            ### Changes
+            ${{ github.event.head_commit.message }}
+          prerelease: true
+          files: |
+            release/*.exe
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-${{ steps.version.outputs.version }}
+          path: release/*.exe
+          retention-days: 30
+

--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -47,6 +47,8 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           SKIP_NOTARIZATION: 'true'
+          npm_config_build_from_source: 'false'
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '0'
 
       - name: Find installer
         id: find-installer

--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -3,7 +3,7 @@ name: Prerelease Build
 on:
   push:
     branches:
-      - 56-create-a-cicd-pipline-for-the-prerelease  # Change to 'prerelease' after testing
+      - prerelease
 
 permissions:
   contents: write  # Required to create releases and tags

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -7,7 +7,7 @@
   },
   "npmRebuild": false,
   "buildDependenciesFromSource": false,
-  "electronRebuild": false,
+  "nodeGypRebuild": false,
   "files": [
     "dist/**/*",
     "dist-electron/**/*",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -8,6 +8,7 @@
   "npmRebuild": false,
   "buildDependenciesFromSource": false,
   "nodeGypRebuild": false,
+  "publish": null,
   "files": [
     "dist/**/*",
     "dist-electron/**/*",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -5,6 +5,9 @@
     "output": "release",
     "buildResources": "build"
   },
+  "npmRebuild": false,
+  "buildDependenciesFromSource": false,
+  "electronRebuild": false,
   "files": [
     "dist/**/*",
     "dist-electron/**/*",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:electron": "tsc -p tsconfig.node.json && node electron-build.config.js",
-    "build:all": "npm run build && npm run build:electron",
+    "build:all": "npm run build:electron && npm run build",
     "preview": "vite preview",
     "electron:dev": "concurrently \"npm run build:electron\" \"vite\" \"wait-on http://localhost:5173 && electron .\"",
     "electron:build:clean": "node scripts/clean-release.js",

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Update package.json version with git commit hash suffix.
+Reads current version, appends short commit hash, and updates package.json.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+def get_git_commit_hash():
+    """Get short git commit hash."""
+    try:
+        result = subprocess.run(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting git commit hash: {e}", file=sys.stderr)
+        sys.exit(1)
+
+def update_version():
+    """Update package.json version with commit hash."""
+    project_root = Path(__file__).parent.parent
+    package_json_path = project_root / 'package.json'
+    
+    # Read package.json
+    try:
+        with open(package_json_path, 'r', encoding='utf-8') as f:
+            package_data = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: {package_json_path} not found", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing package.json: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Get current version
+    current_version = package_data.get('version', '1.0.0-prerelease.0')
+    print(f"Current version: {current_version}")
+    
+    # Get commit hash
+    commit_hash = get_git_commit_hash()
+    print(f"Git commit hash: {commit_hash}")
+    
+    # Check if version already has commit hash
+    if f"-{commit_hash}" in current_version:
+        print(f"Version already includes commit hash: {current_version}")
+        new_version = current_version
+    else:
+        # Append commit hash to version
+        new_version = f"{current_version}-{commit_hash}"
+        print(f"New version: {new_version}")
+        
+        # Update package.json
+        package_data['version'] = new_version
+        try:
+            with open(package_json_path, 'w', encoding='utf-8') as f:
+                json.dump(package_data, f, indent=2, ensure_ascii=False)
+                f.write('\n')  # Add trailing newline
+            print(f"Updated {package_json_path} with version: {new_version}")
+        except Exception as e:
+            print(f"Error writing package.json: {e}", file=sys.stderr)
+            sys.exit(1)
+    
+    # Output version for GitHub Actions using GITHUB_OUTPUT
+    github_output = os.environ.get('GITHUB_OUTPUT')
+    if github_output:
+        try:
+            with open(github_output, 'a') as f:
+                f.write(f"version={new_version}\n")
+        except Exception as e:
+            print(f"Warning: Could not write to GITHUB_OUTPUT: {e}", file=sys.stderr)
+    
+    return new_version
+
+if __name__ == '__main__':
+    update_version()
+

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -1,0 +1,228 @@
+// Type definitions for Electron API exposed via preload script
+// This file ensures TypeScript recognizes window.electronAPI in the renderer process
+
+type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
+type LogArgs = Parameters<typeof console.log>;
+
+declare global {
+  interface Window {
+    electronAPI: {
+      selectPDFFile: () => Promise<string | null>;
+      selectImageFile: () => Promise<string | null>;
+      selectSaveDirectory: () => Promise<string | null>;
+      validatePDFForExtraction: (pdfPath: string) => Promise<{ valid: boolean; path: string }>;
+      saveFiles: (options: {
+        saveDirectory: string;
+        saveParentFile: boolean;
+        saveToZip: boolean;
+        folderName?: string;
+        parentFilePath?: string;
+        extractedPages: Array<{ pageNumber: number; imageData: string }>;
+      }) => Promise<{ success: boolean; messages: string[] }>;
+      validatePath: (filePath: string) => Promise<{ isValid: boolean; isPDF: boolean }>;
+      readPDFFile: (filePath: string) => Promise<{ type: 'base64'; data: string } | { type: 'file-path'; path: string } | string | number[]>;
+      readPDFFileChunk: (filePath: string, start: number, length: number) => Promise<ArrayBuffer>;
+      closePDFFileHandle: (filePath: string) => Promise<void>;
+      getPDFFileSize: (filePath: string) => Promise<number>;
+      // Archive APIs
+      selectArchiveDrive: () => Promise<{ path: string; autoDetected: boolean } | null>;
+      getArchiveConfig: () => Promise<{ archiveDrive: string | null }>;
+      validateArchiveDirectory: (dirPath: string) => Promise<{ isValid: boolean; marker?: { version: string; createdAt: number; lastModified: number; caseCount?: number; archiveId: string } }>;
+      createCaseFolder: (caseName: string, description?: string, categoryTagId?: string) => Promise<string>;
+      getCategoryTags: () => Promise<Array<{ id: string; name: string; color: string }>>;
+      createCategoryTag: (tag: { id: string; name: string; color: string }) => Promise<{ id: string; name: string; color: string }>;
+      deleteCategoryTag: (tagId: string) => Promise<boolean>;
+      setCaseCategoryTag: (casePath: string, categoryTagId: string | null) => Promise<boolean>;
+      getCaseCategoryTag: (casePath: string) => Promise<string | null>;
+      setFileCategoryTag: (filePath: string, categoryTagId: string | null) => Promise<boolean>;
+      getFileCategoryTag: (filePath: string) => Promise<string | null>;
+      createFolder: (folderPath: string, folderName: string) => Promise<string>;
+      createExtractionFolder: (casePath: string, folderName: string, parentPdfPath?: string) => Promise<string>;
+      moveFileToFolder: (filePath: string, folderPath: string) => Promise<{ success: boolean; error?: string; newPath?: string }>;
+      listArchiveCases: () => Promise<Array<{ name: string; path: string; backgroundImage?: string; description?: string; categoryTagId?: string }>>;
+      listCaseFiles: (casePath: string) => Promise<Array<{ name: string; path: string; size: number; modified: number; isFolder?: boolean; folderType?: 'extraction' | 'case'; parentPdfName?: string; categoryTagId?: string }>>;
+      addFilesToCase: (casePath: string, filePaths?: string[]) => Promise<string[]>;
+      deleteCase: (casePath: string) => Promise<boolean>;
+      setCaseBackgroundImage: (casePath: string, imagePath: string) => Promise<string>;
+      setFolderBackgroundImage: (folderPath: string, imagePath: string) => Promise<string>;
+      deleteFile: (filePath: string, isFolder?: boolean) => Promise<boolean>;
+      renameFile: (filePath: string, newName: string) => Promise<{ success: boolean; newPath: string }>;
+      getFileThumbnail: (filePath: string) => Promise<string>;
+      getPDFThumbnailPath: (filePath: string) => Promise<string>;
+      savePDFThumbnail: (filePath: string, thumbnailData: string) => Promise<void>;
+      readPDFThumbnail: (filePath: string) => Promise<string | null>;
+      deletePDFThumbnail: (filePath: string) => Promise<void>;
+      readFileData: (filePath: string) => Promise<{ data: string; mimeType: string; fileName: string }>;
+      extractPDFFromArchive: (options: {
+        pdfPath: string;
+        casePath: string;
+        folderName: string;
+        saveParentFile: boolean;
+        extractedPages: Array<{ pageNumber: number; imageData: string }>;
+      }) => Promise<{ success: boolean; messages: string[]; extractionFolder: string }>;
+      logToMain: (level: LogLevel, ...args: LogArgs) => Promise<void>;
+      debugLog: (logEntry: {
+        location: string;
+        message: string;
+        data?: any;
+        timestamp: number;
+        sessionId: string;
+        runId: string;
+        hypothesisId: string;
+      }) => Promise<void>;
+      getSystemMemory: () => Promise<{ totalMemory: number; freeMemory: number; usedMemory: number }>;
+      // Settings API
+      getSettings: () => Promise<{
+        hardwareAcceleration: boolean;
+        ramLimitMB: number;
+        fullscreen: boolean;
+        extractionQuality: 'high' | 'medium' | 'low';
+        thumbnailSize: number;
+        performanceMode: 'auto' | 'high' | 'balanced' | 'low';
+      }>;
+      updateSettings: (updates: Partial<{
+        hardwareAcceleration: boolean;
+        ramLimitMB: number;
+        fullscreen: boolean;
+        extractionQuality: 'high' | 'medium' | 'low';
+        thumbnailSize: number;
+        performanceMode: 'auto' | 'high' | 'balanced' | 'low';
+      }>) => Promise<{
+        hardwareAcceleration: boolean;
+        ramLimitMB: number;
+        fullscreen: boolean;
+        extractionQuality: 'high' | 'medium' | 'low';
+        thumbnailSize: number;
+        performanceMode: 'auto' | 'high' | 'balanced' | 'low';
+      }>;
+      toggleFullscreen: () => Promise<boolean>;
+      // Word Editor API
+      getVaultDirectory: () => Promise<string | null>;
+      listTextFiles: () => Promise<Array<{
+        name: string;
+        path: string;
+        size: number;
+        modified: number;
+        preview?: string;
+      }>>;
+      readTextFile: (filePath: string) => Promise<string>;
+      createTextFile: (fileName: string, content: string) => Promise<string>;
+      saveTextFile: (filePath: string, content: string) => Promise<{ success: boolean }>;
+      deleteTextFile: (filePath: string) => Promise<{ success: boolean }>;
+      // Case Notes API
+      listCaseNotes: (casePath: string) => Promise<Array<{
+        name: string;
+        path: string;
+        size: number;
+        modified: number;
+        preview?: string;
+      }>>;
+      createCaseNote: (casePath: string, fileName: string, content: string) => Promise<string>;
+      exportTextFile: (options: {
+        content: string;
+        format: 'pdf' | 'docx' | 'rtf';
+        filePath?: string;
+      }) => Promise<{ success: boolean; filePath: string }>;
+      createWordEditorWindow: (options: {
+        content: string;
+        filePath?: string | null;
+        viewState?: 'editor' | 'library' | 'bookmarkLibrary';
+        casePath?: string | null;
+      }) => Promise<{ success: boolean }>;
+      reattachWordEditor: (options: {
+        content: string;
+        filePath?: string | null;
+        viewState?: 'editor' | 'library' | 'bookmarkLibrary';
+        casePath?: string | null;
+      }) => Promise<{ success: boolean }>;
+      createPdfAuditWindow: (options: {
+        pdfPath: string | null;
+        settings: {
+          blackThreshold: number;
+          minOverlapArea: number;
+          minHits: number;
+          includeSecurityAudit: boolean;
+        };
+        showSettings: boolean;
+        result: any | null;
+        isAuditing: boolean;
+        progressMessage: string;
+      }) => Promise<{ success: boolean }>;
+      reattachPdfAudit: (options: {
+        pdfPath: string | null;
+        settings: {
+          blackThreshold: number;
+          minOverlapArea: number;
+          minHits: number;
+          includeSecurityAudit: boolean;
+        };
+        showSettings: boolean;
+        result: any | null;
+        isAuditing: boolean;
+        progressMessage: string;
+      }) => Promise<{ success: boolean }>;
+      closeWindow: () => Promise<{ success: boolean }>;
+      openBookmarkInMainWindow: (options: {
+        pdfPath: string;
+        pageNumber: number;
+      }) => Promise<{ success: boolean }>;
+      // Bookmark API
+      getBookmarks: () => Promise<Array<any>>;
+      createBookmark: (bookmark: any) => Promise<any>;
+      updateBookmark: (id: string, updates: any) => Promise<any>;
+      deleteBookmark: (id: string) => Promise<boolean>;
+      getBookmarkFolders: () => Promise<Array<any>>;
+      createBookmarkFolder: (folder: any) => Promise<any>;
+      deleteBookmarkFolder: (id: string) => Promise<boolean>;
+      getBookmarksByFolder: (folderId: string | null) => Promise<Array<any>>;
+      saveBookmarkThumbnail: (bookmarkId: string, thumbnailData: string) => Promise<string>;
+      getBookmarkThumbnail: (bookmarkId: string) => Promise<string | null>;
+      // File Security Checker API
+      auditPDFRedaction: (pdfPath: string, options?: {
+        blackThreshold?: number;
+        minOverlapArea?: number;
+        minHits?: number;
+        includeSecurityAudit?: boolean;
+      }) => Promise<{
+        filename: string;
+        totalPages: number;
+        flaggedPages: Array<{
+          pageNumber: number;
+          blackRectCount: number;
+          overlapCount: number;
+          confidenceScore: number;
+        }>;
+        security?: {
+          has_metadata: boolean;
+          metadata_keys: string[];
+          has_attachments: boolean;
+          attachment_count: number;
+          has_annotations: boolean;
+          annotation_count: number;
+          has_forms: boolean;
+          form_field_count: number;
+          has_layers: boolean;
+          layer_count: number;
+          has_javascript: boolean;
+          has_actions: boolean;
+          has_thumbnails: boolean;
+          incremental_updates_suspected: boolean;
+          notes: string[];
+        };
+        error?: string;
+      }>;
+      onAuditProgress: (callback: (message: string) => void) => () => void;
+      onAuditResult: (callback: (result: any) => void) => () => void;
+      onAuditError: (callback: (error: string) => void) => () => void;
+      generateAuditReport: (auditResult: any, outputPath: string) => Promise<{ success: boolean; outputPath?: string; error?: string }>;
+      showSaveDialog: (options: {
+        title: string;
+        defaultPath: string;
+        filters: Array<{ name: string; extensions: string[] }>;
+      }) => Promise<{ canceled: boolean; filePath?: string }>;
+    };
+  }
+}
+
+export {};
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,8 @@
     },
     "types": ["node", "vite/client"]
   },
-  "include": ["src", "electron"],
-  "exclude": ["src/test-utils", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+  "include": ["src"],
+  "exclude": ["src/test-utils", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "electron", "dist-electron"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }
 


### PR DESCRIPTION
# Add GitHub Actions Workflow for Automated Prerelease Builds

## Overview

This PR implements an automated CI/CD pipeline that builds Electron Windows installers and creates GitHub Releases when code is merged into the prerelease branch. The workflow uses automatic versioning based on git commit hashes and skips code signing (as configured).

## What's New

### 🚀 Automated Prerelease Builds
- **GitHub Actions Workflow**: Automatically builds Windows installers on push to the prerelease branch
- **Automatic Versioning**: Appends git commit hash to version (e.g., `1.0.0-prerelease.4-abc1234`)
- **GitHub Release Creation**: Automatically creates prerelease with installer attached
- **Artifact Upload**: Stores build artifacts for 30 days

### 📝 Key Features
- ✅ Builds Windows NSIS installer automatically
- ✅ Creates GitHub Release with installer as asset
- ✅ Automatic versioning with commit hash
- ✅ Code signing disabled (as per existing configuration)
- ✅ No testing in workflow (build only, as requested)

## Files Changed

### New Files
- **`.github/workflows/prerelease-build.yml`**: Main GitHub Actions workflow
  - Triggers on push to prerelease branch (currently set to test branch)
  - Sets up Node.js 20 and Python
  - Builds Electron app
  - Creates GitHub Release
  - Uploads artifacts

- **`scripts/update-version.py`**: Python script for automatic versioning
  - Reads current version from `package.json`
  - Gets short git commit hash
  - Appends commit hash to version
  - Updates `package.json` with new version

- **`src/types/electronAPI.d.ts`**: TypeScript type definitions
  - Extends Window interface with `electronAPI` types
  - Resolves TypeScript compilation errors in CI

### Modified Files
- **`electron-builder.json`**: Build configuration updates
  - Added `npmRebuild: false` - Skip npm rebuild
  - Added `buildDependenciesFromSource: false` - Don't build from source
  - Added `nodeGypRebuild: false` - Skip node-gyp rebuilds (prevents canvas rebuild issues)
  - Added `publish: null` - Disable auto-publish (we handle releases manually)

- **`tsconfig.json`**: TypeScript configuration fixes
  - Excluded `electron` and `dist-electron` from main config
  - Prevents TypeScript conflicts between electron and main app builds

- **`package.json`**: Build script order fix
  - Changed `build:all` to build electron first, then main app
  - Prevents build order conflicts

## How It Works

1. **Trigger**: Workflow triggers on push to prerelease branch
2. **Setup**: Installs Node.js 20, Python, and dependencies
3. **Versioning**: Python script updates version with commit hash
4. **Build**: Runs `npm run electron:build` to create Windows installer
5. **Release**: Creates GitHub Release with installer attached
6. **Artifacts**: Uploads installer as workflow artifact

## Configuration

### Current Setup (Testing)
- Workflow triggers on: `56-create-a-cicd-pipline-for-the-prerelease` branch
- **Action Required**: After testing, change line 6 in `.github/workflows/prerelease-build.yml` to:
  - prerelease
  ### Version Format
- Base version: `1.0.0-prerelease.4`
- With commit hash: `1.0.0-prerelease.4-abc1234`
- Release tag: `v1.0.0-prerelease.4-abc1234`

## Testing

✅ **Successfully tested** on current branch:
- Build completes successfully
- Installer created: `Vault Setup 1.0.0-prerelease.4-{hash}.exe`
- GitHub Release created automatically
- Artifacts uploaded correctly

## Build Configuration

### Code Signing
- Disabled (as per existing configuration)
- Uses `CSC_IDENTITY_AUTO_DISCOVERY=false`
- No signing certificates required

### Native Dependencies
- Configured to skip rebuilding native dependencies
- Prevents issues with packages like `canvas` that require system libraries
- Uses pre-built binaries when available

## Next Steps

1. ✅ Test workflow on current branch (completed)
2. ⏳ Change workflow trigger to `prerelease` branch
3. ⏳ Merge to prerelease branch to activate workflow

## Notes

- Workflow builds **Windows only** (as requested)
- No testing included in workflow (build only)
- Python script handles version management
- Release notes auto-generated from commit messages
- Artifacts retained for 30 days

## Screenshots/Logs

Workflow successfully:
- ✅ Built Electron app
- ✅ Created Windows installer
- ✅ Created GitHub Release
- ✅ Uploaded artifacts

---

**Ready for merge** - Change branch trigger to `prerelease` after review.