### PR TITLE
🚨 Emergency Fix - Double-Back Button Navigation Issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: file:; font-src 'self' data:; connect-src 'self' file: blob: http://127.0.0.1:7243; worker-src 'self' blob:; media-src 'self' vault-video:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: file:; font-src 'self' data:; connect-src 'self' file: blob:; worker-src 'self' blob:; media-src 'self' vault-video:;" />
     <title>Vault</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vault",
-  "version": "1.0.0-prerelease.3",
+  "version": "1.0.0-prerelease.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vault",
-      "version": "1.0.0-prerelease.3",
+      "version": "1.0.0-prerelease.4",
       "dependencies": {
         "@lexical/code": "^0.19.0",
         "@lexical/html": "^0.19.0",
@@ -58,6 +58,10 @@
         "vite": "^5.0.8",
         "vitest": "^1.1.0",
         "wait-on": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/components/Archive/ArchivePage.tsx
+++ b/src/components/Archive/ArchivePage.tsx
@@ -82,18 +82,30 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
   // Restore currentCase from ArchiveContext on mount if local state is null
   // This fixes the issue where ArchivePage remounts (due to layout changes) and loses case selection
   useEffect(() => {
+    // #region agent log
+    if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:84', message: 'Restoration useEffect: Entry', data: { hasRestoredCase: hasRestoredCaseRef.current, casesLength: cases.length, currentCaseIsNull: currentCase === null, archiveContextCaseIsNull: archiveContextCase === null, archiveContextCasePath: archiveContextCase?.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'A' }).catch(() => { });
+    // #endregion
     // Only restore if:
     // 1. We haven't already attempted restoration
     // 2. Cases are loaded (we need the list to validate)
     // 3. Local currentCase is null (we just mounted/remounted)
     // 4. ArchiveContext has a case (there was a previous selection)
     if (!hasRestoredCaseRef.current && cases.length > 0 && currentCase === null && archiveContextCase !== null) {
+      // #region agent log
+      if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:90', message: 'Restoration useEffect: Conditions met, checking case existence', data: { archiveContextCasePath: archiveContextCase.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'A' }).catch(() => { });
+      // #endregion
       // Verify the case still exists in our cases list
       const caseExists = cases.some(c => c.path === archiveContextCase.path);
       if (caseExists) {
+        // #region agent log
+        if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:94', message: 'Restoration useEffect: Restoring case from context', data: { casePath: archiveContextCase.path, caseName: archiveContextCase.name }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'A' }).catch(() => { });
+        // #endregion
         setCurrentCase(archiveContextCase);
         hasRestoredCaseRef.current = true;
       } else {
+        // #region agent log
+        if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:97', message: 'Restoration useEffect: Case not found, marking as restored', data: { archiveContextCasePath: archiveContextCase.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'A' }).catch(() => { });
+        // #endregion
         // Case doesn't exist anymore, mark as restored to prevent retrying
         hasRestoredCaseRef.current = true;
       }
@@ -106,13 +118,26 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
   // IMPORTANT: Don't overwrite context with null during remounts if context has a case
   // (we'll restore from context in useEffect, then sync back)
   useLayoutEffect(() => {
+    // #region agent log
+    if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:108', message: 'Sync useLayoutEffect: Entry', data: { currentCaseIsNull: currentCase === null, currentCasePath: currentCase?.path, archiveContextCaseIsNull: archiveContextCase === null, archiveContextCasePath: archiveContextCase?.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'C' }).catch(() => { });
+    // #endregion
     // Always sync non-null values
     // For null values, only sync if context is also null (don't overwrite during remount)
     if (currentCase !== null) {
+      // #region agent log
+      if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:111', message: 'Sync useLayoutEffect: Syncing non-null case to context', data: { casePath: currentCase.path, caseName: currentCase.name }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'C' }).catch(() => { });
+      // #endregion
       setArchiveContextCase(currentCase);
     } else if (archiveContextCase === null) {
+      // #region agent log
+      if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:113', message: 'Sync useLayoutEffect: Both null, syncing null to context', data: {}, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'C' }).catch(() => { });
+      // #endregion
       // Both are null, sync to keep them in sync
       setArchiveContextCase(null);
+    } else {
+      // #region agent log
+      if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:117', message: 'Sync useLayoutEffect: Skipping sync - currentCase null but context has case', data: { archiveContextCasePath: archiveContextCase.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'C' }).catch(() => { });
+      // #endregion
     }
     // If currentCase is null but archiveContextCase is not, skip syncing
     // This allows the useEffect to restore from context first
@@ -806,7 +831,16 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
               </button>
               {currentCase && (
                 <button
-                  onClick={() => setCurrentCase(null)}
+                  onClick={() => {
+                    // #region agent log
+                    if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:809', message: 'Back button clicked', data: { currentCasePath: currentCase.path, currentCaseName: currentCase.name, hasRestoredCase: hasRestoredCaseRef.current, archiveContextCasePath: archiveContextCase?.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'A' }).catch(() => { });
+                    // #endregion
+                    // Clear both local state and context to prevent restoration
+                    setCurrentCase(null);
+                    setArchiveContextCase(null);
+                    // Reset restoration flag so it can restore in the future if needed
+                    hasRestoredCaseRef.current = false;
+                  }}
                   className="flex items-center gap-2 px-3 py-2 bg-gray-800/80 hover:bg-gray-700 text-white rounded-full border border-cyber-purple-500/60 shadow-sm transition-colors"
                   aria-label="Go back to cases list"
                 >
@@ -1571,7 +1605,12 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                     key={caseItem.path}
                     caseItem={caseItem}
                     isExtracting={isExtracting && extractingCasePath === caseItem.path}
-                    onClick={() => setCurrentCase(caseItem)}
+                    onClick={() => {
+                      // #region agent log
+                      if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:1574', message: 'Case clicked', data: { casePath: caseItem.path, caseName: caseItem.name, currentCasePath: currentCase?.path, hasRestoredCase: hasRestoredCaseRef.current, archiveContextCasePath: archiveContextCase?.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'E' }).catch(() => { });
+                      // #endregion
+                      setCurrentCase(caseItem);
+                    }}
                     onDelete={() => deleteCase(caseItem.path)}
                     onRename={() => {
                       setFileToRename({

--- a/src/components/Archive/ArchivePage.tsx
+++ b/src/components/Archive/ArchivePage.tsx
@@ -861,10 +861,12 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
               <button
                 onClick={goBackToParentFolder}
                 className="flex items-center gap-2 px-3 py-2 bg-gray-800/80 hover:bg-gray-700 text-white rounded-full border border-cyber-purple-500/60 shadow-sm transition-colors mt-2"
-                aria-label={`Go back to ${folderNavigationStack.length > 0 ? 'parent folder' : 'case'}`}
+                aria-label={`Go back to ${folderNavigationStack.length > 0 && folderNavigationStack[folderNavigationStack.length - 1] !== currentCase.path ? 'parent folder' : 'case'}`}
               >
                 <ArrowLeft size={18} aria-hidden="true" />
-                <span className="text-sm font-medium">Back to {folderNavigationStack.length > 0 ? 'Parent' : 'Case'}</span>
+                <span className="text-sm font-medium">
+                  Back to {folderNavigationStack.length > 0 && folderNavigationStack[folderNavigationStack.length - 1] !== currentCase.path ? 'Parent' : 'Case'}
+                </span>
               </button>
             )}
           </div>

--- a/src/components/SecurityCheckerModal.tsx
+++ b/src/components/SecurityCheckerModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Shield, X, FileText, AlertTriangle, CheckCircle, Loader2, Upload, Settings, Download, Maximize2, Zap, Lock, FolderOpen } from 'lucide-react';
 import { useRedactionAudit, RedactionAuditResult } from '../hooks/useRedactionAudit';
@@ -334,9 +335,10 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
   return (
     <AnimatePresence>
       {isOpen && (
-        <>
+        <React.Fragment key="security-checker-modal">
           {/* Backdrop */}
           <motion.div
+            key="backdrop"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -346,6 +348,7 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
 
           {/* Modal */}
           <motion.div
+            key="modal"
             initial={{ opacity: 0, scale: 0.9, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.9, y: 20 }}
@@ -1033,15 +1036,18 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
               </div>
             </div>
           </motion.div>
-        </>
+        </React.Fragment>
       )}
 
       {/* Case Selection Dialog */}
-      <CaseSelectionDialog
-        isOpen={showCaseSelectionDialog}
-        onClose={() => setShowCaseSelectionDialog(false)}
-        onSelectCase={handleCaseSelected}
-      />
+      {showCaseSelectionDialog && (
+        <CaseSelectionDialog
+          key="case-selection-dialog"
+          isOpen={showCaseSelectionDialog}
+          onClose={() => setShowCaseSelectionDialog(false)}
+          onSelectCase={handleCaseSelected}
+        />
+      )}
     </AnimatePresence>
   );
 }

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -27,15 +27,9 @@ export function SettingsPanel({ hideWordEditorButton = false, isArchiveVisible =
   // Listen for reattach data from detached window
   useEffect(() => {
     const handleReattach = (_event: CustomEvent<{ content: string; filePath?: string | null; viewState?: 'editor' | 'library' | 'bookmarkLibrary'; casePath?: string | null }>) => {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'SettingsPanel.tsx:handleReattach:entry',message:'Reattach event received',data:{viewState:_event.detail.viewState,casePath:_event.detail.casePath},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-      // #endregion
       // Open the word editor panel when reattaching
       setIsWordEditorOpen(true);
       setWordEditorContextOpen(true);
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'SettingsPanel.tsx:handleReattach:afterOpen',message:'Word editor opened',data:{willNavigateToCase:false,casePath:_event.detail.casePath},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-      // #endregion
     };
 
     // Listen for bookmark open events that should close the word editor

--- a/src/components/WordEditor/DetachedWordEditor.tsx
+++ b/src/components/WordEditor/DetachedWordEditor.tsx
@@ -26,9 +26,6 @@ export function DetachedWordEditor() {
     // We'll use a custom event listener
     const handleData = (_event: CustomEvent<{ content: string; filePath?: string | null; viewState?: 'editor' | 'library' | 'bookmarkLibrary'; casePath?: string | null }>) => {
       const data = _event.detail;
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'DetachedWordEditor.tsx:handleData:entry',message:'Received word-editor-data event',data:{viewState:data.viewState,filePath:data.filePath,casePath:data.casePath},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
-      // #endregion
       console.log('DetachedWordEditor: Received word-editor-data event', { viewState: data.viewState, filePath: data.filePath, casePath: data.casePath });
 
       // Set the content in the editor by updating the DOM directly
@@ -47,9 +44,6 @@ export function DetachedWordEditor() {
       // Restore view state - always set it explicitly to ensure correct state
       const viewState = data.viewState || 'editor';
       console.log('DetachedWordEditor: Setting view state to', viewState);
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'DetachedWordEditor.tsx:handleData:beforeState',message:'About to set view state',data:{viewState,casePath:data.casePath},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
-      // #endregion
 
       if (viewState === 'bookmarkLibrary') {
         setShowBookmarkLibrary(true);
@@ -61,9 +55,6 @@ export function DetachedWordEditor() {
         setShowBookmarkLibrary(false);
         setShowLibrary(true);
         console.log('DetachedWordEditor: Set showBookmarkLibrary=false, showLibrary=true');
-        // #region agent log
-        fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'DetachedWordEditor.tsx:handleData:libraryState',message:'Set showLibrary=true',data:{casePath:data.casePath},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
-        // #endregion
         // Clear loading immediately for library views
         setIsInitializing(false);
       } else {

--- a/src/components/WordEditor/TextLibrary.tsx
+++ b/src/components/WordEditor/TextLibrary.tsx
@@ -275,28 +275,10 @@ export function TextLibrary({ onOpenFile, onNewFile, onClose, isDetached = false
   // For case gallery, show immediately - don't wait for contextStabilized to avoid showing files first
   // Check for both null and undefined since currentCase?.path can be undefined
   const shouldShowGallery = showGallery || ((effectiveCasePath === null || effectiveCasePath === undefined) && selectedCaseForNotes === null);
-  // #region agent log
-  useEffect(() => {
-    fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:shouldShowGallery:calc',message:'shouldShowGallery calculated',data:{shouldShowGallery,showGallery,effectiveCasePath,currentCasePath:currentCase?.path,currentCaseName:currentCase?.name,selectedCasePath:selectedCaseForNotes?.path,detachedCasePath,contextStabilized},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-  }, [shouldShowGallery, showGallery, effectiveCasePath, currentCase, selectedCaseForNotes, detachedCasePath, contextStabilized]);
-  // #endregion
-  // #region agent log
-  useEffect(() => {
-    if (window.electronAPI?.debugLog) {
-      window.electronAPI.debugLog({location:'TextLibrary.tsx:shouldShowGallery',message:'shouldShowGallery calculated',data:{shouldShowGallery,showGallery,contextStabilized,currentCasePath:currentCase?.path,currentCaseName:currentCase?.name,selectedCasePath:selectedCaseForNotes?.path,isDetached},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'}).catch(()=>{});
-    }
-  }, [shouldShowGallery, showGallery, contextStabilized, currentCase, selectedCaseForNotes, isDetached]);
-  // #endregion
 
   useEffect(() => {
-    // #region agent log
-    fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:entry',message:'Load files effect running',data:{contextStabilized,selectedCasePath:selectedCaseForNotes?.path,currentCasePath:currentCase?.path,showGallery,detachedCasePath},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-    // #endregion
     // Wait for context to stabilize before loading files
     if (!contextStabilized) {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:earlyReturn',message:'Context not stabilized, returning early',data:{contextStabilized},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'D'})}).catch(()=>{});
-      // #endregion
       return;
     }
     
@@ -304,9 +286,6 @@ export function TextLibrary({ onOpenFile, onNewFile, onClose, isDetached = false
     const effectiveCasePath = detachedCasePath || currentCase?.path;
     // Check for both null and undefined since currentCase?.path can be undefined
     const shouldShowGalleryCalc = showGallery || ((effectiveCasePath === null || effectiveCasePath === undefined) && selectedCaseForNotes === null);
-    // #region agent log
-    fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:calc',message:'Calculated shouldShowGalleryCalc',data:{shouldShowGalleryCalc,showGallery,effectiveCasePath,selectedCasePath:selectedCaseForNotes?.path},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-    // #endregion
     
     // Load files when:
     // 1. A case is selected from gallery
@@ -315,27 +294,14 @@ export function TextLibrary({ onOpenFile, onNewFile, onClose, isDetached = false
     // IMPORTANT: Don't load files if we should show the gallery - let the gallery render instead
     // IMPORTANT: Always prioritize showing case notes if currentCase exists
     if (selectedCaseForNotes?.path) {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:branch1',message:'Loading files for selectedCaseForNotes',data:{selectedCasePath:selectedCaseForNotes?.path},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-      // #endregion
       loadFiles();
     } else if (currentCase?.path && !showGallery) {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:branch2',message:'Loading files for currentCase',data:{currentCasePath:currentCase?.path},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-      // #endregion
       // When in a case, show that case's notes by default - this is the most important case
       loadFiles();
     } else if (!currentCase && !shouldShowGalleryCalc) {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:branch3',message:'Loading global files',data:{currentCase:null,shouldShowGalleryCalc},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-      // #endregion
       // Load global files if not in a case and NOT showing gallery
       // If shouldShowGalleryCalc is true, we should show the gallery instead, so don't load files
       loadFiles();
-    } else {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:loadFilesEffect:branch4',message:'Not loading files, should show gallery',data:{shouldShowGalleryCalc,currentCase:currentCase?.name},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
-      // #endregion
     }
     // If shouldShowGalleryCalc is true, we don't load files - the gallery will be shown instead
   }, [selectedCaseForNotes?.path, currentCase?.path, showGallery, contextStabilized, detachedCasePath]);
@@ -461,12 +427,7 @@ export function TextLibrary({ onOpenFile, onNewFile, onClose, isDetached = false
   // Double-check: even if shouldShowGallery is true, if currentCase exists and user didn't explicitly request it, don't show gallery
   // When in case gallery (currentCase === null), show gallery immediately
   // When in a case, wait for context to stabilize to avoid race conditions
-  // #region agent log
   const willShowGallery = shouldShowGallery && (!currentCase || contextStabilized);
-  useEffect(() => {
-    fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'TextLibrary.tsx:galleryCheck',message:'Gallery display check',data:{willShowGallery,shouldShowGallery,currentCase:currentCase?.name,contextStabilized,showGallery},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-  }, [willShowGallery, shouldShowGallery, currentCase, contextStabilized, showGallery]);
-  // #endregion
   if (willShowGallery) {
     // Enhanced gallery for detached mode
     if (isDetached) {

--- a/src/components/WordEditor/WordEditorPanel.tsx
+++ b/src/components/WordEditor/WordEditorPanel.tsx
@@ -56,9 +56,6 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
 
   // Auto-show case notes library when opening panel from case gallery
   useEffect(() => {
-    // #region agent log
-    fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'WordEditorPanel.tsx:autoOpenLibrary:entry',message:'Auto-open library effect running',data:{isOpen,currentCase:currentCase?.name,showLibrary,showBookmarkLibrary,currentFilePath,hasAutoOpened:hasAutoOpenedLibraryRef.current},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
-    // #endregion
     // Reset flag when panel closes
     if (!isOpen) {
       hasAutoOpenedLibraryRef.current = false;
@@ -67,9 +64,6 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
 
     // Auto-open library only once when panel opens from case gallery
     if (isOpen && !currentCase && !showLibrary && !showBookmarkLibrary && !currentFilePath && !hasAutoOpenedLibraryRef.current) {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'WordEditorPanel.tsx:autoOpenLibrary:setting',message:'Setting showLibrary to true',data:{isOpen,currentCase:null,showLibrary:false},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
-      // #endregion
       // If we're in the case gallery (no currentCase) and panel just opened,
       // automatically show the library (which will show the case notes gallery)
       setShowLibrary(true);
@@ -138,9 +132,6 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
   }, []);
 
   const handleDetach = async () => {
-    // #region agent log
-    fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'WordEditorPanel.tsx:handleDetach:entry',message:'handleDetach called',data:{showLibrary,showBookmarkLibrary,currentCasePath:currentCase?.path,currentCaseName:currentCase?.name},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-    // #endregion
     try {
       if (!window.electronAPI) {
         toast.error('Electron API not available');
@@ -159,9 +150,6 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
       }
 
       console.log('WordEditorPanel: Detaching with viewState', viewState, { showBookmarkLibrary, showLibrary });
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'WordEditorPanel.tsx:handleDetach:beforeCreate',message:'About to create detached window',data:{viewState,currentCasePath:currentCase?.path,currentCaseName:currentCase?.name,willPassCasePath:false},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-      // #endregion
 
       // Create detached window - pass case path if available
       await window.electronAPI.createWordEditorWindow({
@@ -170,9 +158,6 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
         viewState,
         casePath: currentCase?.path || null,
       } as Parameters<typeof window.electronAPI.createWordEditorWindow>[0]);
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'WordEditorPanel.tsx:handleDetach:afterCreate',message:'Detached window created',data:{viewState,currentCasePath:currentCase?.path},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-      // #endregion
 
       // Close panel after detaching
       onClose();
@@ -180,9 +165,6 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
     } catch (error) {
       toast.error('Failed to open editor in separate window');
       console.error('Detach error:', error);
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/04b3394c-36fd-4b4f-81b5-5b895f23f78b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'WordEditorPanel.tsx:handleDetach:error',message:'Detach failed',data:{error:error instanceof Error?error.message:String(error)},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-      // #endregion
     }
   };
 

--- a/src/contexts/ArchiveContext.tsx
+++ b/src/contexts/ArchiveContext.tsx
@@ -20,6 +20,9 @@ export function ArchiveContextProvider({ children }: ArchiveContextProviderProps
 
   // Wrapped setCurrentCase that tracks state changes
   const setCurrentCaseWithTracking = useCallback((caseItem: ArchiveCase | null) => {
+    // #region agent log
+    if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchiveContext.tsx:22', message: 'ArchiveContext setCurrentCase called', data: { caseItemIsNull: caseItem === null, caseItemPath: caseItem?.path, caseItemName: caseItem?.name, previousCasePath: lastCaseRef.current?.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'B' }).catch(() => { });
+    // #endregion
     // Always update the state - don't prevent legitimate clears
     // But track the last case for debugging purposes
     if (caseItem !== null) {

--- a/src/hooks/useArchive.ts
+++ b/src/hooks/useArchive.ts
@@ -1289,8 +1289,12 @@ export function useArchive() {
     if (!currentCase) return;
     
     // Add current folder to navigation stack if we're already in a folder
+    // If we're at case root (currentFolderPath is null), add the case path to track that we came from root
     if (currentFolderPath) {
       setFolderNavigationStack(prev => [...prev, currentFolderPath]);
+    } else {
+      // We're at case root, add case path to stack so we can navigate back
+      setFolderNavigationStack(prev => [...prev, currentCase.path]);
     }
     setCurrentFolderPath(folderPath);
   }, [currentCase, currentFolderPath]);
@@ -1304,12 +1308,17 @@ export function useArchive() {
     if (folderNavigationStack.length > 0) {
       const parentPath = folderNavigationStack[folderNavigationStack.length - 1];
       setFolderNavigationStack(prev => prev.slice(0, -1));
-      setCurrentFolderPath(parentPath);
+      // If parent path is the case path, we're going back to case root
+      if (currentCase && parentPath === currentCase.path) {
+        setCurrentFolderPath(null);
+      } else {
+        setCurrentFolderPath(parentPath);
+      }
     } else {
       // If no parent in stack, go back to case root
       setCurrentFolderPath(null);
     }
-  }, [folderNavigationStack]);
+  }, [folderNavigationStack, currentCase]);
 
   const navigateToFolder = useCallback((targetPath: string) => {
     // If navigating to case root


### PR DESCRIPTION
### Priority: HIGH - Emergency Update
This PR fixes a critical navigation bug that was causing users to have to click the back button twice to return from a case view to the case gallery on the first navigation.

---

## 📋 Summary

Fixed a race condition in the ArchivePage navigation system where clicking the back button to return from a case view to the case gallery required two clicks on the first navigation, but only one click on subsequent navigations.

---

## 🐛 Problem

When users clicked the back button to exit a case:
1. `setCurrentCase(null)` cleared the local state
2. The `useLayoutEffect` intentionally skipped clearing the `ArchiveContext` (to prevent overwriting during remounts)
3. The restoration `useEffect` detected that the context still had a case and automatically restored it
4. This caused the case to reappear, requiring a second back click

**User Impact:**
- Poor UX requiring double-clicks
- Confusing navigation behavior
- Inconsistent behavior between first and subsequent navigations

---

## ✅ Solution

Modified the back button handler in `ArchivePage.tsx` to explicitly clear both local state and context when navigating back:

onClick={() => {
  // Clear both local state and context to prevent restoration
  setCurrentCase(null);
  setArchiveContextCase(null);
  // Reset restoration flag so it can restore in the future if needed
  hasRestoredCaseRef.current = false;
}}
