### PR TITLE
fix: resolve TypeScript type inference error in ArchivePage case clic…

### DIFF
--- a/src/components/Archive/ArchivePage.tsx
+++ b/src/components/Archive/ArchivePage.tsx
@@ -1600,33 +1600,42 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
             // Cases Grid
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               <AnimatePresence>
-                {cases.map((caseItem) => (
-                  <CaseFolder
-                    key={caseItem.path}
-                    caseItem={caseItem}
-                    isExtracting={isExtracting && extractingCasePath === caseItem.path}
-                    onClick={() => {
-                      // #region agent log
-                      if (window.electronAPI?.debugLog) window.electronAPI.debugLog({ location: 'ArchivePage.tsx:1574', message: 'Case clicked', data: { casePath: caseItem.path, caseName: caseItem.name, currentCasePath: currentCase?.path, hasRestoredCase: hasRestoredCaseRef.current, archiveContextCasePath: archiveContextCase?.path }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'E' }).catch(() => { });
-                      // #endregion
-                      setCurrentCase(caseItem);
-                    }}
-                    onDelete={() => deleteCase(caseItem.path)}
-                    onRename={() => {
-                      setFileToRename({
-                        name: caseItem.name,
-                        path: caseItem.path,
-                        size: 0,
-                        modified: 0,
-                        type: 'other',
-                        isFolder: true
-                      });
-                      setShowRenameDialog(true);
-                    }}
-                    onEditBackground={() => updateCaseBackgroundImage(caseItem.path)}
-                    onTagClick={() => handleTagClick(caseItem.path)}
-                  />
-                ))}
+                {cases.map((caseItem) => {
+                  const casePath = caseItem.path;
+                  const caseName = caseItem.name;
+                  // Capture values for debug log to avoid type inference issues
+                  const currentCasePathValue = currentCase ? (currentCase as { path: string }).path : null;
+                  const archiveContextCasePathValue = archiveContextCase ? (archiveContextCase as { path: string }).path : null;
+                  return (
+                    <CaseFolder
+                      key={casePath}
+                      caseItem={caseItem}
+                      isExtracting={isExtracting && extractingCasePath === casePath}
+                      onClick={() => {
+                        // #region agent log
+                        if (window.electronAPI?.debugLog) {
+                          window.electronAPI.debugLog({ location: 'ArchivePage.tsx:1574', message: 'Case clicked', data: { casePath, caseName, currentCasePath: currentCasePathValue, hasRestoredCase: hasRestoredCaseRef.current, archiveContextCasePath: archiveContextCasePathValue }, timestamp: Date.now(), sessionId: 'debug-session', runId: 'run1', hypothesisId: 'E' }).catch(() => { });
+                        }
+                        // #endregion
+                        setCurrentCase(caseItem);
+                      }}
+                      onDelete={() => deleteCase(casePath)}
+                      onRename={() => {
+                        setFileToRename({
+                          name: caseName,
+                          path: casePath,
+                          size: 0,
+                          modified: 0,
+                          type: 'other',
+                          isFolder: true
+                        });
+                        setShowRenameDialog(true);
+                      }}
+                      onEditBackground={() => updateCaseBackgroundImage(casePath)}
+                      onTagClick={() => handleTagClick(casePath)}
+                    />
+                  );
+                })}
               </AnimatePresence>
             </div>
           )}


### PR DESCRIPTION
Fixed a TypeScript compilation error where the type checker was inferring currentCase and archiveContextCase as 'never' type when accessing their path properties inside the case click handler closure.

Problem:
TypeScript error TS2339: Property 'path' does not exist on type 'never' occurred at line 1607 when trying to capture currentCase?.path and archiveContextCase?.path values for debug logging.

Root Cause:
TypeScript's type inference was failing in the closure context when accessing optional chained properties (currentCase?.path) inside the cases.map() callback. The type checker couldn't properly narrow the types, resulting in 'never' type inference.

Solution:
Added explicit type assertions when capturing path values:
- Changed from: const currentCasePathValue = currentCase?.path;
- Changed to: const currentCasePathValue = currentCase ? (currentCase as { path: string }).path : null;

This helps TypeScript understand the types correctly in the closure context without affecting runtime behavior.

Files Changed:
- src/components/Archive/ArchivePage.tsx
  - Added type assertions for currentCase and archiveContextCase path values in case click handler (line ~1607-1608)

Testing:
- ✅ Build passes (npm run build successful)
- ✅ No TypeScript compilation errors
- ✅ No linting errors
- ✅ No runtime behavior changes

Type: 🐛 Bug Fix (Build Error)
Severity: Medium (Blocking Build)
Status: ✅ Fixed