### PR TITLE
Fix: Prevent PDF Viewer from Closing When Reattaching Side Panel

### DIFF
--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -27,6 +27,9 @@ export function SettingsPanel({ hideWordEditorButton = false, isArchiveVisible =
   // Listen for reattach data from detached window
   useEffect(() => {
     const handleReattach = (_event: CustomEvent<{ content: string; filePath?: string | null; viewState?: 'editor' | 'library' | 'bookmarkLibrary'; casePath?: string | null }>) => {
+      // Use the same event that opening from viewer uses to ensure consistent behavior
+      // This ensures the PDF viewer's ref is set immediately
+      window.dispatchEvent(new CustomEvent('open-word-editor-from-viewer'));
       setIsWordEditorOpen(true);
       setWordEditorContextOpen(true);
     };


### PR DESCRIPTION
### Summary
Fixed a bug where reattaching the detached word editor panel would immediately close the PDF viewer. The issue occurred because DOM mutations during reattach triggered click events on the backdrop that closed the viewer before the word editor state could update.

### Problem
When a user:
1. Opens a PDF in the viewer
2. Opens the word editor side panel
3. Detaches the panel (works fine)
4. Reattaches the panel → **PDF viewer immediately closes** ❌

This was inconsistent with opening the panel from the viewer, which worked correctly.

### Solution
- Made reattach use the same `open-word-editor-from-viewer` event mechanism as opening from viewer (which already worked correctly)
- Added `isReattachingRef` to track reattach state and prevent closing during DOM mutations
- Added event listener in `ArchiveFileViewer` to immediately set protection refs when reattach event fires
- Updated both backdrop click handlers to check reattaching state
- Fixed TypeScript build errors for `dragConstraintsRef` type (added `false` to union type to match framer-motion API)

### Changes
- `src/components/Archive/ArchiveFileViewer.tsx`
  - Added `isReattachingRef` and `reattachTimeoutRef` refs
  - Enhanced reattach event listener to set protection refs immediately
  - Added listener for `open-word-editor-from-viewer` event (same handler)
  - Updated backdrop click handlers to check `isReattachingRef`
  - Fixed `dragConstraintsRef` type to include `false` in union type
  - Improved type guard for drag constraints comparison

- `src/components/Settings/SettingsPanel.tsx`
  - Updated reattach handler to dispatch `open-word-editor-from-viewer` event
  - Ensures consistent behavior with opening from viewer

### Testing
- ✅ Build completes successfully
- ✅ No TypeScript errors
- ✅ No linting errors
- ✅ Reattach now uses same code path as opening from viewer (which was already working)

### Verification Steps
1. Open a PDF in the archive viewer
2. Open the word editor side panel (should work)
3. Detach the side panel (should work)
4. Reattach the side panel → **PDF viewer should remain open** ✅

### Type
🐛 Bug Fix