### PR TITLE
Fix: PDF Drag Jitter + Loading Screen Design Update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -352,10 +352,47 @@ function AppContent() {
             >
               <Suspense
                 fallback={
-                  <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 flex items-center justify-center">
-                    <div className="text-center">
-                      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-                      <p className="text-gray-300">Loading Archive...</p>
+                  <div className="relative min-h-screen bg-gradient-to-br from-gray-950 via-purple-950/50 to-gray-950 flex items-center justify-center overflow-hidden">
+                    {/* Animated Background Grid */}
+                    <div 
+                      className="absolute inset-0 opacity-20"
+                      style={{
+                        backgroundImage: `
+                          linear-gradient(rgba(139, 92, 246, 0.1) 1px, transparent 1px),
+                          linear-gradient(90deg, rgba(139, 92, 246, 0.1) 1px, transparent 1px)
+                        `,
+                        backgroundSize: '50px 50px',
+                        maskImage: 'radial-gradient(ellipse 80% 50% at 50% 50%, black 40%, transparent 100%)',
+                      }}
+                    />
+                    
+                    {/* Content */}
+                    <div className="relative z-10 text-center space-y-6">
+                      {/* Modern Spinner with Gradient */}
+                      <div className="inline-flex items-center justify-center">
+                        <div className="relative">
+                          {/* Outer Glow Ring */}
+                          <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+                          <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+                          
+                          {/* Main Spinner */}
+                          <div className="relative w-16 h-16">
+                            <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                            <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                          </div>
+                          
+                          {/* Center Glow */}
+                          <div className="absolute inset-4 bg-gradient-to-br from-cyber-purple-400/20 to-cyber-cyan-400/20 rounded-full blur-xl"></div>
+                        </div>
+                      </div>
+                      
+                      {/* Loading Text */}
+                      <div className="space-y-2">
+                        <p className="text-xl font-semibold bg-gradient-to-r from-cyber-purple-400 via-cyber-cyan-400 to-cyber-purple-400 bg-clip-text text-transparent bg-[length:200%_auto] animate-[shimmer_3s_linear_infinite]">
+                          Loading Archive...
+                        </p>
+                        <p className="text-sm text-gray-400 font-medium">Initializing vault systems</p>
+                      </div>
                     </div>
                   </div>
                 }
@@ -393,10 +430,47 @@ function AppContent() {
         >
           <Suspense
             fallback={
-              <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 flex items-center justify-center">
-                <div className="text-center">
-                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-                  <p className="text-gray-300">Loading Archive...</p>
+              <div className="relative min-h-screen bg-gradient-to-br from-gray-950 via-purple-950/50 to-gray-950 flex items-center justify-center overflow-hidden">
+                {/* Animated Background Grid */}
+                <div 
+                  className="absolute inset-0 opacity-20"
+                  style={{
+                    backgroundImage: `
+                      linear-gradient(rgba(139, 92, 246, 0.1) 1px, transparent 1px),
+                      linear-gradient(90deg, rgba(139, 92, 246, 0.1) 1px, transparent 1px)
+                    `,
+                    backgroundSize: '50px 50px',
+                    maskImage: 'radial-gradient(ellipse 80% 50% at 50% 50%, black 40%, transparent 100%)',
+                  }}
+                />
+                
+                {/* Content */}
+                <div className="relative z-10 text-center space-y-6">
+                  {/* Modern Spinner with Gradient */}
+                  <div className="inline-flex items-center justify-center">
+                    <div className="relative">
+                      {/* Outer Glow Ring */}
+                      <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+                      <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+                      
+                      {/* Main Spinner */}
+                      <div className="relative w-16 h-16">
+                        <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                        <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                      </div>
+                      
+                      {/* Center Glow */}
+                      <div className="absolute inset-4 bg-gradient-to-br from-cyber-purple-400/20 to-cyber-cyan-400/20 rounded-full blur-xl"></div>
+                    </div>
+                  </div>
+                  
+                  {/* Loading Text */}
+                  <div className="space-y-2">
+                    <p className="text-xl font-semibold bg-gradient-to-r from-cyber-purple-400 via-cyber-cyan-400 to-cyber-purple-400 bg-clip-text text-transparent bg-[length:200%_auto] animate-[shimmer_3s_linear_infinite]">
+                      Loading Archive...
+                    </p>
+                    <p className="text-sm text-gray-400 font-medium">Initializing vault systems</p>
+                  </div>
                 </div>
               </div>
             }
@@ -438,10 +512,47 @@ function AppContent() {
     // This shouldn't happen, but just in case
     return (
       <>
-        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 flex items-center justify-center">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-            <p className="text-gray-300">Preparing...</p>
+        <div className="relative min-h-screen bg-gradient-to-br from-gray-950 via-purple-950/50 to-gray-950 flex items-center justify-center overflow-hidden">
+          {/* Animated Background Grid */}
+          <div 
+            className="absolute inset-0 opacity-20"
+            style={{
+              backgroundImage: `
+                linear-gradient(rgba(139, 92, 246, 0.1) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(139, 92, 246, 0.1) 1px, transparent 1px)
+              `,
+              backgroundSize: '50px 50px',
+              maskImage: 'radial-gradient(ellipse 80% 50% at 50% 50%, black 40%, transparent 100%)',
+            }}
+          />
+          
+          {/* Content */}
+          <div className="relative z-10 text-center space-y-6">
+            {/* Modern Spinner with Gradient */}
+            <div className="inline-flex items-center justify-center">
+              <div className="relative">
+                {/* Outer Glow Ring */}
+                <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+                <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+                
+                {/* Main Spinner */}
+                <div className="relative w-16 h-16">
+                  <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                  <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                </div>
+                
+                {/* Center Glow */}
+                <div className="absolute inset-4 bg-gradient-to-br from-cyber-purple-400/20 to-cyber-cyan-400/20 rounded-full blur-xl"></div>
+              </div>
+            </div>
+            
+            {/* Loading Text */}
+            <div className="space-y-2">
+              <p className="text-xl font-semibold bg-gradient-to-r from-cyber-purple-400 via-cyber-cyan-400 to-cyber-purple-400 bg-clip-text text-transparent bg-[length:200%_auto] animate-[shimmer_3s_linear_infinite]">
+                Preparing...
+              </p>
+              <p className="text-sm text-gray-400 font-medium">Initializing extraction systems</p>
+            </div>
           </div>
         </div>
         <SettingsPanel isArchiveVisible={false} hideFixedButtons={true} />

--- a/src/components/Archive/ArchiveFileViewer.tsx
+++ b/src/components/Archive/ArchiveFileViewer.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence, useMotionValue } from 'framer-motion';
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { X, ZoomIn, ZoomOut, ChevronLeft, ChevronRight, FileText, BookmarkPlus, Bookmark } from 'lucide-react';
 import { ArchiveFile, PDFDocument, PDFRenderTask } from '../../types';
 import { logger } from '../../utils/logger';
@@ -1383,7 +1383,7 @@ export function ArchiveFileViewer({ file, files, onClose, onNext, onPrevious, in
                         document.body.style.cursor = 'grabbing';
                         // Ensure constraints are set before drag starts
                         // Recalculate constraints at drag start in case panel just opened/resized
-                        if (!dragConstraintsRef.current || dragConstraintsRef.current === false) {
+                        if (!dragConstraintsRef.current) {
                           requestAnimationFrame(() => {
                             if (!isPdfDraggingRef.current) return; // Double check we're still starting drag
                             const constraints = calculateDragConstraints();

--- a/src/components/Archive/ArchiveFileViewer.tsx
+++ b/src/components/Archive/ArchiveFileViewer.tsx
@@ -1166,10 +1166,19 @@ export function ArchiveFileViewer({ file, files, onClose, onNext, onPrevious, in
           {file.type === 'pdf' ? (
             <>
               {pdfLoading ? (
-                <div className="flex flex-col items-center justify-center w-full h-full bg-gray-900 rounded-lg">
-                  <div className="text-center mb-4">
-                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-                    <p className="text-gray-300 mb-2">
+                <div className="flex flex-col items-center justify-center w-full h-full bg-gradient-to-br from-gray-950 via-purple-950/30 to-gray-950 rounded-lg">
+                  <div className="text-center mb-4 space-y-4">
+                    <div className="inline-flex items-center justify-center">
+                      <div className="relative">
+                        <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+                        <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+                        <div className="relative w-12 h-12">
+                          <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                          <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                        </div>
+                      </div>
+                    </div>
+                    <p className="text-gray-300 font-medium bg-gradient-to-r from-cyber-purple-400 via-cyber-cyan-400 to-cyber-purple-400 bg-clip-text text-transparent">
                       {pdfLoadingProgress < 90 ? 'Reading file...' : 'Parsing PDF...'}
                     </p>
                     {pdfLoadingProgress > 0 && (
@@ -1312,10 +1321,15 @@ export function ArchiveFileViewer({ file, files, onClose, onNext, onPrevious, in
                     }}
                   >
                     {pageRendering && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-gray-900/80 backdrop-blur-sm rounded z-10">
-                        <div className="text-center">
-                          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyber-purple-400 mx-auto mb-2"></div>
-                          <p className="text-gray-300 text-sm">Loading page...</p>
+                      <div className="absolute inset-0 flex items-center justify-center bg-gray-900/90 backdrop-blur-sm rounded z-10">
+                        <div className="text-center space-y-2">
+                          <div className="inline-flex items-center justify-center">
+                            <div className="relative w-8 h-8">
+                              <div className="absolute inset-0 rounded-full border-2 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                              <div className="absolute inset-1 rounded-full border border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                            </div>
+                          </div>
+                          <p className="text-gray-300 text-sm font-medium">Loading page...</p>
                         </div>
                       </div>
                     )}
@@ -1390,10 +1404,19 @@ export function ArchiveFileViewer({ file, files, onClose, onNext, onPrevious, in
               )}
             </>
           ) : loading ? (
-            <div className="flex items-center justify-center w-full h-96 bg-gray-900 rounded-lg">
-              <div className="text-center">
-                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-                <p className="text-gray-300">Loading...</p>
+            <div className="flex items-center justify-center w-full h-96 bg-gradient-to-br from-gray-950 via-purple-950/30 to-gray-950 rounded-lg">
+              <div className="text-center space-y-4">
+                <div className="inline-flex items-center justify-center">
+                  <div className="relative">
+                    <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+                    <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+                    <div className="relative w-12 h-12">
+                      <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                      <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                    </div>
+                  </div>
+                </div>
+                <p className="text-gray-300 font-medium">Loading...</p>
               </div>
             </div>
           ) : fileData ? (

--- a/src/components/Archive/CaseSelectionDialog.tsx
+++ b/src/components/Archive/CaseSelectionDialog.tsx
@@ -86,9 +86,14 @@ export function CaseSelectionDialog({
           <div className="flex-1 overflow-y-auto min-h-0">
             {loading ? (
               <div className="flex items-center justify-center py-12">
-                <div className="text-center">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-                  <p className="text-gray-400">Loading cases...</p>
+                <div className="text-center space-y-4">
+                  <div className="inline-flex p-4 bg-gradient-to-br from-cyan-900/40 to-purple-900/40 rounded-2xl border-2 border-cyber-cyan-400/30">
+                    <div className="relative w-8 h-8">
+                      <div className="absolute inset-0 rounded-full border-2 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                      <div className="absolute inset-1 rounded-full border border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                    </div>
+                  </div>
+                  <p className="text-gray-300 text-sm font-medium">Loading cases...</p>
                 </div>
               </div>
             ) : cases.length === 0 ? (

--- a/src/components/Bookmarks/BookmarkCard.tsx
+++ b/src/components/Bookmarks/BookmarkCard.tsx
@@ -97,7 +97,10 @@ export function BookmarkCard({ bookmark, onDelete, isDetached = false }: Bookmar
       <div className="relative w-full h-32 bg-gray-900 overflow-hidden">
         {loading ? (
           <div className="w-full h-full flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyber-purple-400"></div>
+            <div className="relative w-8 h-8">
+              <div className="absolute inset-0 rounded-full border-2 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+              <div className="absolute inset-1 rounded-full border border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+            </div>
           </div>
         ) : thumbnail ? (
           <img

--- a/src/components/Bookmarks/BookmarkFolderCard.tsx
+++ b/src/components/Bookmarks/BookmarkFolderCard.tsx
@@ -80,7 +80,10 @@ export function BookmarkFolderCard({ folder, onOpen, onDelete, isDetached = fals
       <div className="relative w-full h-32 bg-gray-900 overflow-hidden">
         {loading ? (
           <div className="w-full h-full flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyber-purple-400"></div>
+            <div className="relative w-8 h-8">
+              <div className="absolute inset-0 rounded-full border-2 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+              <div className="absolute inset-1 rounded-full border border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+            </div>
           </div>
         ) : thumbnail ? (
           <img

--- a/src/components/Bookmarks/BookmarkLibrary.tsx
+++ b/src/components/Bookmarks/BookmarkLibrary.tsx
@@ -138,9 +138,18 @@ export function BookmarkLibrary({ isDetached = false }: BookmarkLibraryProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-          <p className="text-gray-300">Loading bookmarks...</p>
+        <div className="text-center space-y-6">
+          <div className="inline-flex p-6 bg-gradient-to-br from-cyan-900/40 to-purple-900/40 rounded-2xl border-2 border-cyber-cyan-400/30">
+            <div className="relative">
+              <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+              <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+              <div className="relative w-12 h-12">
+                <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+              </div>
+            </div>
+          </div>
+          <p className="text-gray-300 text-lg">Loading bookmarks...</p>
         </div>
       </div>
     );

--- a/src/components/WordEditor/TextLibrary.tsx
+++ b/src/components/WordEditor/TextLibrary.tsx
@@ -664,9 +664,18 @@ export function TextLibrary({ onOpenFile, onNewFile, onClose, isDetached = false
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-          <p className="text-gray-300">Loading files...</p>
+        <div className="text-center space-y-6">
+          <div className="inline-flex p-6 bg-gradient-to-br from-cyan-900/40 to-purple-900/40 rounded-2xl border-2 border-cyber-cyan-400/30">
+            <div className="relative">
+              <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+              <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+              <div className="relative w-12 h-12">
+                <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+              </div>
+            </div>
+          </div>
+          <p className="text-gray-300 text-lg">Loading files...</p>
         </div>
       </div>
     );

--- a/src/components/WordEditor/WordEditor.tsx
+++ b/src/components/WordEditor/WordEditor.tsx
@@ -680,10 +680,19 @@ export const WordEditor = forwardRef<WordEditorHandle, WordEditorProps>(
       <div className="flex-1 overflow-auto p-4 relative">
         {/* Loading overlay */}
         {isLoading && (
-          <div className="absolute inset-0 bg-gray-900/80 backdrop-blur-sm flex items-center justify-center z-10 rounded-lg">
-            <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyber-purple-400 mx-auto mb-4"></div>
-              <p className="text-gray-300">Loading file...</p>
+          <div className="absolute inset-0 bg-gray-900/90 backdrop-blur-xl flex items-center justify-center z-10 rounded-lg">
+            <div className="text-center space-y-4">
+              <div className="inline-flex items-center justify-center">
+                <div className="relative">
+                  <div className="absolute inset-0 border-4 border-cyber-purple-400/40 rounded-full animate-spin" style={{ animationDuration: '2s' }}></div>
+                  <div className="absolute inset-2 border-2 border-cyber-cyan-400/50 rounded-full animate-spin" style={{ animationDuration: '1.5s', animationDirection: 'reverse' }}></div>
+                  <div className="relative w-12 h-12">
+                    <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+                    <div className="absolute inset-2 rounded-full border-2 border-transparent border-b-cyber-cyan-400 border-l-cyber-purple-400 animate-spin" style={{ animationDuration: '1.2s', animationDirection: 'reverse' }}></div>
+                  </div>
+                </div>
+              </div>
+              <p className="text-gray-300 font-medium">Loading file...</p>
             </div>
           </div>
         )}
@@ -758,7 +767,9 @@ export const WordEditor = forwardRef<WordEditorHandle, WordEditorProps>(
           {/* Saving indicator */}
           {isSaving && (
             <div className="flex items-center gap-2 text-cyber-purple-400 text-xs">
-              <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-cyber-purple-400"></div>
+              <div className="relative w-3 h-3">
+                <div className="absolute inset-0 rounded-full border border-transparent border-t-cyber-purple-400 border-r-cyber-cyan-400 animate-spin"></div>
+              </div>
               <span>Saving...</span>
             </div>
           )}


### PR DESCRIPTION
### Summary
- **Fixed PDF drag jitter** in side panel viewer by locking constraints during drag
- **Updated all loading screens** to match modern design aesthetic with dual-ring spinners and gradients

### PDF Drag Fix
- Added stable constraints state that locks during drag operations
- Blocked constraint updates during active drag
- Fixed TypeScript errors and removed unused imports

### Loading Screen Updates
- Replaced old purple-heavy loaders with modern dual-ring animated spinners
- Added gradient backgrounds and animated grid patterns
- Updated 8+ components for consistent design
- Applied cyber-purple/cyan color scheme throughout

### Testing
1. **PDF Drag**: Open side panel → PDF → Zoom → Drag (should be smooth)
2. **Loading Screens**: Navigate app and verify all loaders show new design

**Files Modified**: ArchiveFileViewer.tsx, App.tsx, TextLibrary, WordEditor, Bookmark components, CaseSelectionDialog