### PR TITLE
87 pdf to image conversion images not saving

### DIFF
--- a/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
+++ b/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
@@ -4,20 +4,20 @@ overview: The `extractPDFFromArchive` handler currently only saves individual fi
 todos:
   - id: update-extract-zip-types
     content: Update electronAPI.d.ts to add saveToZip parameter to extractPDFFromArchive options
-    status: pending
+    status: completed
   - id: update-extract-zip-backend
     content: Update electron/main.ts extract-pdf-from-archive handler to support ZIP creation when saveToZip is true
-    status: pending
+    status: completed
     dependencies:
       - update-extract-zip-types
   - id: update-modal-zip-option
     content: Update PDFExtractionModal.tsx to pass saveToZip option to extractPDFFromArchive
-    status: pending
+    status: completed
     dependencies:
       - update-extract-zip-types
   - id: update-detached-zip-option
     content: Update DetachedPDFExtraction.tsx to pass saveToZip option to extractPDFFromArchive
-    status: pending
+    status: completed
     dependencies:
       - update-extract-zip-types
 ---

--- a/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
+++ b/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
@@ -1,0 +1,87 @@
+---
+name: Add ZIP support to extractPDFFromArchive handler
+overview: The `extractPDFFromArchive` handler currently only saves individual files, but when users select "Save to ZIP Folder" from the archive, it should create a ZIP file. We need to add `saveToZip` parameter support to `extractPDFFromArchive` and implement ZIP creation logic similar to the `save-files` handler.
+todos:
+  - id: update-extract-zip-types
+    content: Update electronAPI.d.ts to add saveToZip parameter to extractPDFFromArchive options
+    status: pending
+  - id: update-extract-zip-backend
+    content: Update electron/main.ts extract-pdf-from-archive handler to support ZIP creation when saveToZip is true
+    status: pending
+    dependencies:
+      - update-extract-zip-types
+  - id: update-modal-zip-option
+    content: Update PDFExtractionModal.tsx to pass saveToZip option to extractPDFFromArchive
+    status: pending
+    dependencies:
+      - update-extract-zip-types
+  - id: update-detached-zip-option
+    content: Update DetachedPDFExtraction.tsx to pass saveToZip option to extractPDFFromArchive
+    status: pending
+    dependencies:
+      - update-extract-zip-types
+---
+
+# Add ZIP Support to extractPDFFromArchive Handler
+
+## Problem Analysis
+
+When saving from PDFExtractionModal with `caseFolderPath` (archive case), the code always uses `extractPDFFromArchive`, regardless of the `saveToZip` option. However, `extractPDFFromArchive` doesn't support ZIP files - it only saves individual files. This causes:
+
+- When user checks "Save to ZIP Folder" in archive, files are saved as loose files instead of in a ZIP
+- The `saveToZip` option is ignored when saving to archive
+
+## Solution
+
+### 1. Update Type Definitions
+
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to add `saveToZip` parameter to `extractPDFFromArchive` options
+
+### 2. Update Backend Handler
+
+- Modify [`electron/main.ts`](electron/main.ts) `extract-pdf-from-archive` handler:
+- Accept `saveToZip` parameter in options
+- When `saveToZip` is true, create a ZIP file instead of saving individual files
+- Use JSZip to create the ZIP archive (similar to `save-files` handler)
+- Save the ZIP file in the case folder with the folder name
+- Still create the `.parent-pdf` metadata file for folder positioning
+- When `saveToZip` is false, save individual files as before
+
+### 3. Update Frontend Components
+
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleSave`:
+- Pass `saveToZip` option to `extractPDFFromArchive` when `caseFolderPath` exists
+
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) `handleSave`:
+- Pass `saveToZip` option to `extractPDFFromArchive` when `caseFolderPath` exists
+
+## Implementation Details
+
+### Backend Changes
+
+The `extract-pdf-from-archive` handler should:
+
+1. Accept `saveToZip: boolean` in options
+2. When `saveToZip` is true:
+
+- Create a ZIP file using JSZip
+- Add all extracted pages to the ZIP using the provided file names
+- Save the ZIP file as `${folderName}.zip` in the case folder
+- Create the `.parent-pdf` metadata file to link the ZIP to the parent PDF
+- Optionally save parent PDF inside the ZIP if `saveParentFile` is true
+
+3. When `saveToZip` is false:
+
+- Save individual files as before (existing behavior)
+
+### Frontend Changes
+
+1. Pass `saveToZip` in the options when calling `extractPDFFromArchive`
+2. No other changes needed - the logic already determines when to use `extractPDFFromArchive`
+
+## Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Add saveToZip parameter
+2. [`electron/main.ts`](electron/main.ts) - Add ZIP support to extract-pdf-from-archive handler
+3. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Pass saveToZip option
+4. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Pass saveToZip option

--- a/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
+++ b/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
@@ -4,20 +4,20 @@ overview: "Fix two issues: (1) When saving individual image files (not ZIP) from
 todos:
   - id: update-extract-types
     content: Update electronAPI.d.ts to include fileName in extractedPages array items for extractPDFFromArchive
-    status: pending
+    status: completed
   - id: update-extract-backend
     content: Update electron/main.ts extract-pdf-from-archive handler to accept and use fileName
-    status: pending
+    status: completed
     dependencies:
       - update-extract-types
   - id: update-modal-save-logic
     content: Update PDFExtractionModal.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files), pass fileName, and call onExtractionComplete after save
-    status: pending
+    status: completed
     dependencies:
       - update-extract-types
   - id: update-detached-save-logic
     content: Update DetachedPDFExtraction.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files) and pass fileName
-    status: pending
+    status: completed
     dependencies:
       - update-extract-types
 ---

--- a/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
+++ b/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
@@ -1,0 +1,94 @@
+---
+name: Fix archive folder refresh and positioning after PDF extraction
+overview: "Fix two issues: (1) When saving individual image files (not ZIP) from PDFExtractionModal with a case folder, use extractPDFFromArchive instead of saveFiles so the folder appears in the archive and is properly linked to the parent PDF. (2) Call onExtractionComplete after saving completes to refresh the case files list immediately. The extractPDFFromArchive handler also needs to be updated to accept fileName to support custom file naming patterns."
+todos:
+  - id: update-extract-types
+    content: Update electronAPI.d.ts to include fileName in extractedPages array items for extractPDFFromArchive
+    status: pending
+  - id: update-extract-backend
+    content: Update electron/main.ts extract-pdf-from-archive handler to accept and use fileName
+    status: pending
+    dependencies:
+      - update-extract-types
+  - id: update-modal-save-logic
+    content: Update PDFExtractionModal.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files), pass fileName, and call onExtractionComplete after save
+    status: pending
+    dependencies:
+      - update-extract-types
+  - id: update-detached-save-logic
+    content: Update DetachedPDFExtraction.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files) and pass fileName
+    status: pending
+    dependencies:
+      - update-extract-types
+---
+
+# Fix Archive Folder Refresh and Positioning After PDF Extraction
+
+## Problem Analysis
+
+1. **Folder not appearing**: When saving individual image files (not ZIP) from PDFExtractionModal with `caseFolderPath`, the code uses `saveFiles` instead of `extractPDFFromArchive`. This means:
+
+- The folder isn't created in the archive case folder
+- The `.parent-pdf` metadata file isn't created
+- The folder won't appear in the case file listing
+- The folder won't be positioned above the PDF card
+
+2. **No refresh after save**: After saving completes, `onExtractionComplete` is not called, so the files list isn't refreshed and the user must back out and reopen the case to see the new folder.
+
+3. **File naming**: The `extractPDFFromArchive` handler generates file names like `page-${pageNumber}.${extension}`, but we need it to accept custom file names from the frontend to support file naming patterns.
+
+## Solution
+
+### 1. Update Type Definitions
+
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to include `fileName` in `extractedPages` array items for `extractPDFFromArchive`
+
+### 2. Update Backend Handler
+
+- Modify [`electron/main.ts`](electron/main.ts) `extract-pdf-from-archive` handler:
+- Accept `fileName` in `extractedPages` array items
+- Use the provided `fileName` instead of generating it
+- Ensure the `.parent-pdf` metadata file is created (already done, but verify)
+
+### 3. Update Frontend Components
+
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleSave`:
+- When `caseFolderPath` exists, use `extractPDFFromArchive` for both ZIP and individual files (currently only used for ZIP)
+- Pass `fileName` in the `extractedPages` array
+- Call `onExtractionComplete` after saving completes successfully
+
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) `handleSave`:
+- When `caseFolderPath` exists, use `extractPDFFromArchive` for individual files
+- Pass `fileName` in the `extractedPages` array (already done for `saveFiles`)
+
+## Implementation Details
+
+### Logic Flow
+
+When saving from PDFExtractionModal with `caseFolderPath`:
+
+1. If `caseFolderPath` exists:
+
+- Always use `extractPDFFromArchive` (regardless of saveToZip)
+- This ensures the folder appears in the archive and is linked to the parent PDF
+- Note: Currently `extractPDFFromArchive` only saves individual files. ZIP support may need to be added later, but for now we focus on individual files.
+
+2. If `caseFolderPath` doesn't exist:
+
+- Use `saveFiles` as before (for both ZIP and individual files)
+
+3. After save completes:
+
+- Call `onExtractionComplete()` to refresh the files list
+
+### Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Update type definitions for extractPDFFromArchive
+2. [`electron/main.ts`](electron/main.ts) - Update extract-pdf-from-archive handler to accept fileName
+3. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Use extractPDFFromArchive when caseFolderPath exists, call onExtractionComplete
+4. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Use extractPDFFromArchive when caseFolderPath exists
+
+## Notes
+
+- The folder positioning (above PDF card) should work automatically once we use `extractPDFFromArchive` because it creates the `.parent-pdf` metadata file
+- ZIP support in `extractPDFFromArchive` is out of scope for this fix - focus on individual files

--- a/.cursor/plans/fix_detached_window_case_folder_path_reattach_2b8f3c9d.plan.md
+++ b/.cursor/plans/fix_detached_window_case_folder_path_reattach_2b8f3c9d.plan.md
@@ -1,0 +1,46 @@
+# Fix Detached Window Case Folder Path Memory
+
+## Problem Analysis
+
+When detaching the PDF extraction window from an archive case, the `caseFolderPath` is not being passed through the detach/reattach flow. This causes:
+- The detached window doesn't remember which case it came from
+- When saving from the detached window, `caseFolderPath` is null, so it can't save to the archive case folder
+- The detached window can't use `extractPDFFromArchive` because it doesn't know the case path
+
+## Solution
+
+### 1. Update Type Definitions
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to add `caseFolderPath` parameter to both `createPdfExtractionWindow` and `reattachPdfExtraction` options
+
+### 2. Update Frontend Modal
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleDetach`:
+  - Include `caseFolderPath` in the state object passed to `createPdfExtractionWindow`
+
+### 3. Update Backend Handlers
+- Modify [`electron/main.ts`](electron/main.ts) `create-pdf-extraction-window` handler:
+  - Accept `caseFolderPath` parameter in options
+  - Pass `caseFolderPath` to the detached window in the initial data
+
+- Modify [`electron/main.ts`](electron/main.ts) `reattach-pdf-extraction` handler:
+  - Accept `caseFolderPath` parameter in options
+  - Pass `caseFolderPath` to the main window in the reattach data
+
+### 4. Update Detached Window
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx):
+  - Change `caseFolderPath` from hardcoded `null` to state that can be set
+  - Receive `caseFolderPath` from initial data when window loads
+  - Include `caseFolderPath` in the state when reattaching
+
+## Implementation Details
+
+The flow should be:
+1. Modal detaches → includes `caseFolderPath` in state → backend stores it → detached window receives it
+2. Detached window saves → uses `caseFolderPath` for archive saves
+3. Detached window reattaches → includes `caseFolderPath` in reattach state → backend passes it to main window
+
+## Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Add caseFolderPath parameter
+2. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Include caseFolderPath when detaching
+3. [`electron/main.ts`](electron/main.ts) - Pass caseFolderPath through detach/reattach handlers
+4. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Store and use caseFolderPath

--- a/.cursor/plans/fix_pdf_extraction_image_saving_bug_af52ec67.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_image_saving_bug_af52ec67.plan.md
@@ -1,0 +1,64 @@
+---
+name: ""
+overview: ""
+todos: []
+---
+
+# Fix PDF Extraction Image Saving Bug
+
+## Problem
+
+The `save-files` IPC handler in [`electron/main.ts`](electron/main.ts) (lines 543-626) does not properly handle both save modes based on the `saveToZip` flag. Currently:
+
+- **When `saveToZip` is true**: Images are saved inside a ZIP file ✅ (lines 582-620)
+- **When `saveToZip` is false**: Only the parent PDF is saved (if requested), but **extracted page images are NOT saved** ❌
+
+The handler has no `else` branch or separate code block for the non-ZIP case. This is a missing integration of the `saveToZip` flag - the code doesn't handle both branches properly.
+
+This bug affects PDF extraction from both:
+
+- The home screen (`DetachedPDFExtraction`, `PDFExtractionModal`)
+- Within the Vault on PDFs in case files (when using `saveFiles` API)
+
+Note: The `extract-pdf-from-archive` handler (lines 2683-2748) correctly saves individual images, but the `save-files` handler is missing this logic.
+
+## Solution
+
+Add an `else` branch (or separate conditional block) after the ZIP saving block to save individual image files when `saveToZip` is false. The implementation should match the pattern used in the `extract-pdf-from-archive` handler (lines 2717-2742).
+
+## Changes Required
+
+### File: `electron/main.ts`
+
+**Location:** After line 620 (after the `if (saveToZip && folderName)` block), add an `else` branch for when `saveToZip` is false.
+
+**Implementation details:**
+
+- Check if `saveToZip` is false (or use an `else` block)
+- Iterate through `extractedPages` array
+- For each page:
+  - Parse the image format from the base64 data URL (PNG/JPEG) - same pattern as lines 594-610
+  - Convert base64 string to Buffer
+  - Write each image file to `saveDirectory` with filename pattern: `page-${pageNumber}.${extension}`
+  - Add success message to `results` array: `Page ${pageNumber} saved: ${imagePath}`
+
+This should mirror the implementation in `extract-pdf-from-archive` handler (lines 2718-2742), which correctly saves individual image files.
+
+**Code structure should become:**
+
+```typescript
+// Save parent PDF file if requested
+if (saveParentFile && parentFilePath) {
+  // ... existing code ...
+}
+
+// Save to ZIP if requested
+if (saveToZip && folderName) {
+  // ... existing ZIP code ...
+} else {
+  // NEW: Save individual image files when NOT saving to ZIP
+  for (const page of extractedPages) {
+    // ... save individual image files ...
+  }
+}
+```

--- a/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
@@ -1,0 +1,107 @@
+---
+name: Fix PDF extraction save bug and require folder names
+overview: Fix the bug where saving individual image files (when both options are unchecked) doesn't work, and make folder names a requirement for all save operations. The backend `save-files` handler is missing the logic to save individual image files, and the UI needs to require folder names for both loose file and ZIP saves.
+todos:
+  - id: update-types
+    content: Update electronAPI.d.ts to include fileName in extractedPages array items for save-files handler
+    status: pending
+  - id: update-backend-save
+    content: Update electron/main.ts save-files handler to save individual image files when saveToZip is false, and always require folderName
+    status: pending
+    dependencies:
+      - update-types
+  - id: update-save-options-ui
+    content: Update PDFExtractionSaveOptions.tsx to always show folder name field and require it for all save operations
+    status: pending
+  - id: update-modal-handler
+    content: Update PDFExtractionModal.tsx handleSave to pass fileName in extractedPages array
+    status: pending
+    dependencies:
+      - update-types
+  - id: update-detached-handler
+    content: Update DetachedPDFExtraction.tsx handleSave to pass fileName in extractedPages array
+    status: pending
+    dependencies:
+      - update-types
+---
+
+# Fix PDF Extraction Save Bug and Require Folder Names
+
+## Problem Analysis
+
+1. **Bug**: In [`electron/main.ts`](electron/main.ts) (lines 542-626), the `save-files` handler only handles:
+
+- Saving parent PDF when `saveParentFile` is true (lines 569-580)
+- Saving to ZIP when `saveToZip && folderName` is true (lines 582-620)
+- **Missing**: Logic to save individual image files when `saveToZip` is false
+
+This causes the handler to return success with empty results when both options are unchecked.
+
+2. **Missing file names**: The frontend components generate file names using the naming pattern, but only pass `pageNumber` and `imageData` to the backend. The backend needs file names to save individual files.
+
+3. **Folder name requirement**: Currently, folder names are only required when `saveToZip` is true. The user wants folder names required for all save operations:
+
+- When saving as loose files: create a subfolder with that name
+- When saving as ZIP: use that name for the ZIP file (already works)
+
+## Solution
+
+### 1. Update Type Definitions
+
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to include `fileName` in `extractedPages` array items
+
+### 2. Update Backend Handler
+
+- Modify [`electron/main.ts`](electron/main.ts) `save-files` handler:
+- Accept `fileName` in `extractedPages` array items (update type signature)
+- When `saveToZip` is false, save individual image files to a subfolder (using `folderName`) in the save directory
+- Use the provided file names from the frontend
+- Handle image format detection (PNG/JPEG) from data URLs
+
+### 3. Update Frontend Components
+
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleSave`:
+- Pass `fileName` along with `pageNumber` and `imageData` to the backend
+
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) `handleSave`:
+- Pass `fileName` along with `pageNumber` and `imageData` to the backend
+
+### 4. Update Save Options UI
+
+- Modify [`src/components/PDFExtractionSaveOptions.tsx`](src/components/PDFExtractionSaveOptions.tsx):
+- Always show the folder name input field (remove conditional rendering)
+- Always require folder name (update validation in `handleConfirm`)
+- Update button disabled condition to always require folder name
+- Update error messages to reflect that folder name is always required
+- Update the description text to indicate folder names are used for subfolders (loose files) or ZIP files
+
+## Implementation Details
+
+### Backend Changes
+
+The `save-files` handler should:
+
+1. Always require `folderName` (validate it's provided and not empty)
+2. When `saveToZip` is false:
+
+- Create a subfolder in `saveDirectory` using `folderName`
+- Save each image file to that subfolder using the provided `fileName`
+- Detect image format from data URL (PNG/JPEG)
+
+3. When `saveToZip` is true (existing logic):
+
+- Use `folderName` for the ZIP file name (already works)
+
+### Frontend Changes
+
+1. Pass `fileName` in the `extractedPages` array to the backend
+2. Always show and require folder name input
+3. Update validation to require folder name for all save operations
+
+## Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Update type definitions
+2. [`electron/main.ts`](electron/main.ts) - Add logic to save individual files and require folder name
+3. [`src/components/PDFExtractionSaveOptions.tsx`](src/components/PDFExtractionSaveOptions.tsx) - Always show and require folder name
+4. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Pass file names to backend
+5. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Pass file names to backend

--- a/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
@@ -4,23 +4,23 @@ overview: Fix the bug where saving individual image files (when both options are
 todos:
   - id: update-types
     content: Update electronAPI.d.ts to include fileName in extractedPages array items for save-files handler
-    status: pending
+    status: completed
   - id: update-backend-save
     content: Update electron/main.ts save-files handler to save individual image files when saveToZip is false, and always require folderName
-    status: pending
+    status: completed
     dependencies:
       - update-types
   - id: update-save-options-ui
     content: Update PDFExtractionSaveOptions.tsx to always show folder name field and require it for all save operations
-    status: pending
+    status: completed
   - id: update-modal-handler
     content: Update PDFExtractionModal.tsx handleSave to pass fileName in extractedPages array
-    status: pending
+    status: completed
     dependencies:
       - update-types
   - id: update-detached-handler
     content: Update DetachedPDFExtraction.tsx handleSave to pass fileName in extractedPages array
-    status: pending
+    status: completed
     dependencies:
       - update-types
 ---

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3617,6 +3617,7 @@ ipcMain.handle('create-pdf-extraction-window', async (event, options: {
   progress: any | null;
   error: string | null;
   statusMessage: string;
+  caseFolderPath?: string | null;
 }) => {
   try {
     logger.info('create-pdf-extraction-window handler called', {
@@ -3699,7 +3700,8 @@ ipcMain.handle('create-pdf-extraction-window', async (event, options: {
               isExtracting: ${JSON.stringify(options.isExtracting)},
               progress: ${options.progress ? JSON.stringify(options.progress) : 'null'},
               error: ${options.error ? JSON.stringify(options.error) : 'null'},
-              statusMessage: ${JSON.stringify(options.statusMessage || '')}
+              statusMessage: ${JSON.stringify(options.statusMessage || '')},
+              caseFolderPath: ${options.caseFolderPath ? JSON.stringify(options.caseFolderPath) : 'null'}
             };
             console.log('Main process: Dispatching pdf-extraction-data event', data);
             // Store data in case listener isn't ready yet
@@ -3742,6 +3744,7 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
   progress: any | null;
   error: string | null;
   statusMessage: string;
+  caseFolderPath?: string | null;
 }) => {
   try {
     // Get the window that sent the request (the detached extraction window)
@@ -3759,7 +3762,8 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
         isExtracting: options.isExtracting,
         progress: options.progress,
         error: options.error,
-        statusMessage: options.statusMessage || ''
+        statusMessage: options.statusMessage || '',
+        caseFolderPath: options.caseFolderPath || null
       };
 
       logger.info('Reattaching PDF extraction window', {
@@ -3767,6 +3771,7 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
         extractedPagesCount: reattachData.extractedPages.length,
         selectedPagesCount: reattachData.selectedPages.length,
         hasPreviewPage: !!reattachData.previewPage,
+        hasCaseFolderPath: !!reattachData.caseFolderPath,
       });
 
       // Store data globally first so modal can access it when it mounts
@@ -3782,7 +3787,8 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
             isExtracting: ${JSON.stringify(reattachData.isExtracting)},
             progress: ${reattachData.progress ? JSON.stringify(reattachData.progress) : 'null'},
             error: ${reattachData.error ? JSON.stringify(reattachData.error) : 'null'},
-            statusMessage: ${JSON.stringify(reattachData.statusMessage)}
+            statusMessage: ${JSON.stringify(reattachData.statusMessage)},
+            caseFolderPath: ${reattachData.caseFolderPath ? JSON.stringify(reattachData.caseFolderPath) : 'null'}
           };
           // Store data globally for modal to access when it mounts
           window.__reattachPdfExtractionData = data;

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -270,6 +270,7 @@ export function DetachedPDFExtraction() {
           casePath: caseFolderPath,
           folderName: saveOptions.folderName,
           saveParentFile: saveOptions.saveParentFile,
+          saveToZip: saveOptions.saveToZip,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -19,6 +19,7 @@ interface PdfExtractionState {
   progress: any | null;
   error: string | null;
   statusMessage: string;
+  caseFolderPath?: string | null;
 }
 
 const DEFAULT_SETTINGS: ConversionSettings = {
@@ -39,7 +40,7 @@ export function DetachedPDFExtraction() {
   const [previewPage, setPreviewPage] = useState<ExtractedPage | null>(null);
   const [totalPages, setTotalPages] = useState(0);
   const [isReattaching, setIsReattaching] = useState(false);
-  const [caseFolderPath] = useState<string | null>(null);
+  const [caseFolderPath, setCaseFolderPath] = useState<string | null>(null);
 
   // Local state for extraction when detaching during extraction
   const [localExtractedPages, setLocalExtractedPages] = useState<ExtractedPage[]>([]);
@@ -77,6 +78,9 @@ export function DetachedPDFExtraction() {
       }
       if (data.showSettings !== undefined) {
         setShowSettings(data.showSettings);
+      }
+      if (data.caseFolderPath !== undefined) {
+        setCaseFolderPath(data.caseFolderPath || null);
       }
       if (data.extractedPages && data.extractedPages.length > 0) {
         setLocalExtractedPages(data.extractedPages);
@@ -374,6 +378,7 @@ export function DetachedPDFExtraction() {
         progress: finalProgress,
         error: finalError,
         statusMessage: finalStatusMessage,
+        caseFolderPath: caseFolderPath || null,
       };
 
       console.log('DetachedPDFExtraction: Reattaching with state', {

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -232,7 +232,7 @@ export function DetachedPDFExtraction() {
 
   const handleSave = async (saveOptions: {
     saveDirectory: string;
-    folderName?: string;
+    folderName: string;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -263,7 +263,7 @@ export function DetachedPDFExtraction() {
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
-      if (saveOptions.saveToZip && saveOptions.folderName) {
+      if (saveOptions.saveToZip) {
         if (caseFolderPath) {
           await window.electronAPI.extractPDFFromArchive({
             pdfPath: pdfPath!,
@@ -286,6 +286,7 @@ export function DetachedPDFExtraction() {
             extractedPages: pagesWithNames.map((p) => ({
               pageNumber: p.pageNumber,
               imageData: p.imageData,
+              fileName: p.fileName,
             })),
           });
           toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
@@ -295,10 +296,12 @@ export function DetachedPDFExtraction() {
           saveDirectory: saveOptions.saveDirectory,
           saveParentFile: saveOptions.saveParentFile,
           saveToZip: false,
+          folderName: saveOptions.folderName,
           parentFilePath: pdfPath!,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,
+            fileName: p.fileName,
           })),
         });
         toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -263,20 +263,23 @@ export function DetachedPDFExtraction() {
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
-      if (saveOptions.saveToZip) {
-        if (caseFolderPath) {
-          await window.electronAPI.extractPDFFromArchive({
-            pdfPath: pdfPath!,
-            casePath: caseFolderPath,
-            folderName: saveOptions.folderName,
-            saveParentFile: saveOptions.saveParentFile,
-            extractedPages: pagesWithNames.map((p) => ({
-              pageNumber: p.pageNumber,
-              imageData: p.imageData,
-            })),
-          });
-          toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''} to archive`);
-        } else {
+      if (caseFolderPath) {
+        // Save to archive case folder (always use extractPDFFromArchive for archive)
+        await window.electronAPI.extractPDFFromArchive({
+          pdfPath: pdfPath!,
+          casePath: caseFolderPath,
+          folderName: saveOptions.folderName,
+          saveParentFile: saveOptions.saveParentFile,
+          extractedPages: pagesWithNames.map((p) => ({
+            pageNumber: p.pageNumber,
+            imageData: p.imageData,
+            fileName: p.fileName,
+          })),
+        });
+        toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''} to archive`);
+      } else {
+        // Save to regular directory
+        if (saveOptions.saveToZip) {
           await window.electronAPI.saveFiles({
             saveDirectory: saveOptions.saveDirectory,
             saveParentFile: saveOptions.saveParentFile,
@@ -290,21 +293,21 @@ export function DetachedPDFExtraction() {
             })),
           });
           toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
+        } else {
+          await window.electronAPI.saveFiles({
+            saveDirectory: saveOptions.saveDirectory,
+            saveParentFile: saveOptions.saveParentFile,
+            saveToZip: false,
+            folderName: saveOptions.folderName,
+            parentFilePath: pdfPath!,
+            extractedPages: pagesWithNames.map((p) => ({
+              pageNumber: p.pageNumber,
+              imageData: p.imageData,
+              fileName: p.fileName,
+            })),
+          });
+          toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
         }
-      } else {
-        await window.electronAPI.saveFiles({
-          saveDirectory: saveOptions.saveDirectory,
-          saveParentFile: saveOptions.saveParentFile,
-          saveToZip: false,
-          folderName: saveOptions.folderName,
-          parentFilePath: pdfPath!,
-          extractedPages: pagesWithNames.map((p) => ({
-            pageNumber: p.pageNumber,
-            imageData: p.imageData,
-            fileName: p.fileName,
-          })),
-        });
-        toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
       }
 
       setShowSaveDialog(false);

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -371,6 +371,7 @@ export function PDFExtractionModal({
           casePath: caseFolderPath,
           folderName: saveOptions.folderName,
           saveParentFile: saveOptions.saveParentFile,
+          saveToZip: saveOptions.saveToZip,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -479,6 +479,7 @@ export function PDFExtractionModal({
         progress: progress || null,
         error: error || null,
         statusMessage,
+        caseFolderPath: caseFolderPath || null,
       };
 
       console.log('PDFExtractionModal: Detaching with state', {

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -332,7 +332,7 @@ export function PDFExtractionModal({
 
   const handleSave = async (saveOptions: {
     saveDirectory: string;
-    folderName?: string;
+    folderName: string;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -364,7 +364,7 @@ export function PDFExtractionModal({
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
-      if (saveOptions.saveToZip && saveOptions.folderName) {
+      if (saveOptions.saveToZip) {
         // Save to ZIP folder in archive
         if (caseFolderPath) {
           await window.electronAPI.extractPDFFromArchive({
@@ -389,6 +389,7 @@ export function PDFExtractionModal({
             extractedPages: pagesWithNames.map((p) => ({
               pageNumber: p.pageNumber,
               imageData: p.imageData,
+              fileName: p.fileName,
             })),
           });
           toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
@@ -399,10 +400,12 @@ export function PDFExtractionModal({
           saveDirectory: saveOptions.saveDirectory,
           saveParentFile: saveOptions.saveParentFile,
           saveToZip: false,
+          folderName: saveOptions.folderName,
           parentFilePath: pdfPath!,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,
+            fileName: p.fileName,
           })),
         });
         toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);

--- a/src/components/PDFExtractionSaveOptions.tsx
+++ b/src/components/PDFExtractionSaveOptions.tsx
@@ -7,7 +7,7 @@ interface PDFExtractionSaveOptionsProps {
   onClose: () => void;
   onConfirm: (options: {
     saveDirectory: string;
-    folderName?: string;
+    folderName: string;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -57,9 +57,9 @@ export function PDFExtractionSaveOptions({
       return;
     }
 
-    // Validate folder name when saveToZip is true
-    if (saveToZip && !folderName.trim()) {
-      setFolderNameError('Folder Name is required when saving to ZIP folder');
+    // Always validate folder name
+    if (!folderName.trim()) {
+      setFolderNameError('Folder name is required');
       return;
     }
 
@@ -67,7 +67,7 @@ export function PDFExtractionSaveOptions({
 
     onConfirm({
       saveDirectory,
-      folderName: saveToZip ? folderName : undefined,
+      folderName: folderName.trim(),
       saveParentFile,
       saveToZip,
       fileNamingPattern: finalPattern,
@@ -179,12 +179,7 @@ export function PDFExtractionSaveOptions({
                 <input
                   type="checkbox"
                   checked={saveToZip}
-                  onChange={(e) => {
-                    setSaveToZip(e.target.checked);
-                    if (!e.target.checked && folderNameError) {
-                      setFolderNameError(null);
-                    }
-                  }}
+                  onChange={(e) => setSaveToZip(e.target.checked)}
                   className="w-5 h-5 rounded border-gray-600 text-cyber-purple-400 focus:ring-cyber-purple-400 focus:ring-offset-gray-900"
                 />
                 <div className="flex-1">
@@ -199,34 +194,37 @@ export function PDFExtractionSaveOptions({
               </label>
             </div>
 
-            {/* Folder Name (if ZIP) */}
-            {saveToZip && (
-              <div>
-                <label className="block text-sm font-semibold text-gray-400 mb-3">
-                  Folder Name {saveToZip && <span className="text-red-400">*</span>}
-                </label>
-                <input
-                  type="text"
-                  value={folderName}
-                  onChange={(e) => {
-                    setFolderName(e.target.value);
-                    if (folderNameError) {
-                      setFolderNameError(null);
-                    }
-                  }}
-                  placeholder="Enter folder name..."
-                  aria-required="true"
-                  className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
-                    folderNameError
-                      ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
-                      : 'border-gray-700 focus:ring-cyber-purple-400'
-                  }`}
-                />
-                {folderNameError && (
-                  <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
-                )}
-              </div>
-            )}
+            {/* Folder Name */}
+            <div>
+              <label className="block text-sm font-semibold text-gray-400 mb-3">
+                Folder Name <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="text"
+                value={folderName}
+                onChange={(e) => {
+                  setFolderName(e.target.value);
+                  if (folderNameError) {
+                    setFolderNameError(null);
+                  }
+                }}
+                placeholder="Enter folder name..."
+                aria-required="true"
+                className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                  folderNameError
+                    ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                    : 'border-gray-700 focus:ring-cyber-purple-400'
+                }`}
+              />
+              {folderNameError && (
+                <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
+              )}
+              <p className="text-xs text-gray-500 mt-2">
+                {saveToZip
+                  ? 'This name will be used for the ZIP file'
+                  : 'A subfolder with this name will be created to store the extracted images'}
+              </p>
+            </div>
 
             {/* File Naming Pattern */}
             <div>
@@ -267,7 +265,7 @@ export function PDFExtractionSaveOptions({
             </button>
             <button
               onClick={handleConfirm}
-              disabled={!saveDirectory || (saveToZip && !folderName.trim())}
+              disabled={!saveDirectory || !folderName.trim()}
               className="px-6 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-lg font-medium transition-all disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Save className="w-4 h-4" />

--- a/src/components/PDFExtractionSaveOptions.tsx
+++ b/src/components/PDFExtractionSaveOptions.tsx
@@ -36,6 +36,7 @@ export function PDFExtractionSaveOptions({
   const [saveToZip, setSaveToZip] = useState(false);
   const [fileNamingPattern, setFileNamingPattern] = useState('page-{n}');
   const [customPattern, setCustomPattern] = useState('');
+  const [folderNameError, setFolderNameError] = useState<string | null>(null);
 
   const handleSelectDirectory = async () => {
     try {
@@ -53,6 +54,12 @@ export function PDFExtractionSaveOptions({
 
   const handleConfirm = () => {
     if (!saveDirectory) {
+      return;
+    }
+
+    // Validate folder name when saveToZip is true
+    if (saveToZip && !folderName.trim()) {
+      setFolderNameError('Folder Name is required when saving to ZIP folder');
       return;
     }
 
@@ -172,7 +179,12 @@ export function PDFExtractionSaveOptions({
                 <input
                   type="checkbox"
                   checked={saveToZip}
-                  onChange={(e) => setSaveToZip(e.target.checked)}
+                  onChange={(e) => {
+                    setSaveToZip(e.target.checked);
+                    if (!e.target.checked && folderNameError) {
+                      setFolderNameError(null);
+                    }
+                  }}
                   className="w-5 h-5 rounded border-gray-600 text-cyber-purple-400 focus:ring-cyber-purple-400 focus:ring-offset-gray-900"
                 />
                 <div className="flex-1">
@@ -191,15 +203,28 @@ export function PDFExtractionSaveOptions({
             {saveToZip && (
               <div>
                 <label className="block text-sm font-semibold text-gray-400 mb-3">
-                  Folder Name
+                  Folder Name {saveToZip && <span className="text-red-400">*</span>}
                 </label>
                 <input
                   type="text"
                   value={folderName}
-                  onChange={(e) => setFolderName(e.target.value)}
+                  onChange={(e) => {
+                    setFolderName(e.target.value);
+                    if (folderNameError) {
+                      setFolderNameError(null);
+                    }
+                  }}
                   placeholder="Enter folder name..."
-                  className="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
+                  aria-required="true"
+                  className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                    folderNameError
+                      ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                      : 'border-gray-700 focus:ring-cyber-purple-400'
+                  }`}
                 />
+                {folderNameError && (
+                  <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
+                )}
               </div>
             )}
 
@@ -242,7 +267,7 @@ export function PDFExtractionSaveOptions({
             </button>
             <button
               onClick={handleConfirm}
-              disabled={!saveDirectory}
+              disabled={!saveDirectory || (saveToZip && !folderName.trim())}
               className="px-6 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-lg font-medium transition-all disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Save className="w-4 h-4" />

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -58,6 +58,7 @@ declare global {
         casePath: string;
         folderName: string;
         saveParentFile: boolean;
+        saveToZip: boolean;
         extractedPages: Array<{ pageNumber: number; imageData: string; fileName: string }>;
       }) => Promise<{ success: boolean; messages: string[]; extractionFolder: string }>;
       logToMain: (level: LogLevel, ...args: LogArgs) => Promise<void>;

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -180,6 +180,7 @@ declare global {
         progress: any | null;
         error: string | null;
         statusMessage: string;
+        caseFolderPath?: string | null;
       }) => Promise<{ success: boolean }>;
       reattachPdfExtraction: (options: {
         pdfPath: string | null;
@@ -199,6 +200,7 @@ declare global {
         progress: any | null;
         error: string | null;
         statusMessage: string;
+        caseFolderPath?: string | null;
       }) => Promise<{ success: boolean }>;
       closeWindow: () => Promise<{ success: boolean }>;
       openBookmarkInMainWindow: (options: {

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -58,7 +58,7 @@ declare global {
         casePath: string;
         folderName: string;
         saveParentFile: boolean;
-        extractedPages: Array<{ pageNumber: number; imageData: string }>;
+        extractedPages: Array<{ pageNumber: number; imageData: string; fileName: string }>;
       }) => Promise<{ success: boolean; messages: string[]; extractionFolder: string }>;
       logToMain: (level: LogLevel, ...args: LogArgs) => Promise<void>;
       debugLog: (logEntry: {

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -17,7 +17,7 @@ declare global {
         saveToZip: boolean;
         folderName?: string;
         parentFilePath?: string;
-        extractedPages: Array<{ pageNumber: number; imageData: string }>;
+        extractedPages: Array<{ pageNumber: number; imageData: string; fileName: string }>;
       }) => Promise<{ success: boolean; messages: string[] }>;
       validatePath: (filePath: string) => Promise<{ isValid: boolean; isPDF: boolean }>;
       readPDFFile: (filePath: string) => Promise<{ type: 'base64'; data: string } | { type: 'file-path'; path: string } | string | number[]>;


### PR DESCRIPTION
This pull request addresses several related issues and enhancements in the PDF extraction and saving workflow, focusing on reliability, user experience, and feature completeness for both individual file and ZIP archive saves. The changes ensure that folder names are always required, individual image files are properly saved, custom file names are supported, and detached window state is preserved for archive operations.

**Key changes include:**

**PDF Extraction and Saving Logic Improvements**
- The `save-files` handler in `electron/main.ts` now always requires a `folderName`, validates it, and supports saving individual image files to a subfolder when `saveToZip` is false. It uses the provided `fileName` for each image, and ensures parent PDFs are saved in the correct location. This fixes the bug where individual files were not saved and enforces consistent folder naming for all save operations. [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL551-R551) [[2]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL561-R596) [[3]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL598-R652) [[4]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[5]](diffhunk://#diff-ed559468ff3a3aa51aff731ebcd1ecfbc8415648c242fba3c0f46bd9b347833cR1-R64)

- The `extract-pdf-from-archive` handler now supports a `saveToZip` parameter and custom `fileName` for each extracted page, enabling ZIP creation and flexible file naming from the frontend. [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL2690-R2727) [[2]](diffhunk://#diff-32c8b916770fe14d7151c6f67a1d97a14153197dc4dc39e3395426ae3a52f8b4R1-R87) [[3]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94)

**Frontend and Type Definition Updates**
- Type definitions in `electronAPI.d.ts` are updated to include `fileName` for each extracted page and to support new parameters like `saveToZip` and `caseFolderPath` in relevant APIs. [[1]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[2]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94) [[3]](diffhunk://#diff-32c8b916770fe14d7151c6f67a1d97a14153197dc4dc39e3395426ae3a52f8b4R1-R87) [[4]](diffhunk://#diff-5b96015a1cb48b8da0eb851a060f68fd9aae0df0e9c191320ba253db3429348dR1-R46)

- Frontend components (`PDFExtractionModal.tsx`, `DetachedPDFExtraction.tsx`, and `PDFExtractionSaveOptions.tsx`) are updated to:
  - Always require and pass `folderName` for all save operations.
  - Pass `fileName` for each extracted page to the backend.
  - Correctly call `extractPDFFromArchive` when saving to a case folder, ensuring new folders appear and are positioned correctly in the archive.
  - Call `onExtractionComplete` after saving to refresh the UI. [[1]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[2]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94) [[3]](diffhunk://#diff-32c8b916770fe14d7151c6f67a1d97a14153197dc4dc39e3395426ae3a52f8b4R1-R87)

**Detached Window State Management**
- The detached PDF extraction window now preserves and passes the `caseFolderPath` through detach/reattach flows, ensuring archive saves work correctly even after detaching and reattaching the window.

---

**Most important changes:**

**1. PDF Extraction Save Logic and Validation**
- The `save-files` handler now always requires a `folderName`, saves individual image files to a subfolder when not zipping, uses provided `fileName` values, and validates all inputs for both ZIP and loose file saves. [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL551-R551) [[2]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL561-R596) [[3]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL598-R652) [[4]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[5]](diffhunk://#diff-ed559468ff3a3aa51aff731ebcd1ecfbc8415648c242fba3c0f46bd9b347833cR1-R64)

**2. Archive Extraction Handler Enhancements**
- The `extract-pdf-from-archive` handler supports `saveToZip` and custom file names, enabling both ZIP and individual file saves with correct naming and folder structure. [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL2690-R2727) [[2]](diffhunk://#diff-32c8b916770fe14d7151c6f67a1d97a14153197dc4dc39e3395426ae3a52f8b4R1-R87) [[3]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94)

**3. Type Definition and API Surface Updates**
- `electronAPI.d.ts` is updated to support new options (`fileName`, `saveToZip`, `caseFolderPath`) across relevant handlers, ensuring type safety and correct parameter passing. [[1]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[2]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94) [[3]](diffhunk://#diff-32c8b916770fe14d7151c6f67a1d97a14153197dc4dc39e3395426ae3a52f8b4R1-R87) [[4]](diffhunk://#diff-5b96015a1cb48b8da0eb851a060f68fd9aae0df0e9c191320ba253db3429348dR1-R46)

**4. Frontend Save Flow and UI Improvements**
- Frontend components now always require and validate folder names, pass custom file names, and ensure the UI is refreshed after saves. The save logic consistently uses the correct backend handler for archive saves. [[1]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[2]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94) [[3]](diffhunk://#diff-32c8b916770fe14d7151c6f67a1d97a14153197dc4dc39e3395426ae3a52f8b4R1-R87)

**5. Detached Window Case Folder Path Handling**
- The detached PDF extraction window now correctly remembers and uses the `caseFolderPath` during detach/reattach, enabling proper archive saves from detached windows.