### PR TITLE
86 pdf to image conversion screen is destroyed when reattaching detached window after completion

### DIFF
--- a/.cursor/plans/fix_pdf_extraction_reattach_state_loss_c7420aae.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_reattach_state_loss_c7420aae.plan.md
@@ -1,0 +1,53 @@
+---
+name: Fix PDF Extraction Reattach State Loss
+overview: Fix the bug where the PDF to Image Conversion modal loses all extracted pages and state when reattaching from a detached window. The issue is caused by a race condition in state restoration and missing caseFolderPath prop handling.
+todos: []
+---
+
+# Fix PDF Extraction Reattach State Loss
+
+## Problem Analysis
+
+When reattaching a detached PDF extraction window after completion, the modal opens but all extracted pages and state are lost. The issue stems from:
+
+1. **Missing `caseFolderPath` prop**: When App.tsx opens the modal for reattach, it doesn't pass the `caseFolderPath` prop that the modal needs
+2. **Race condition in state restoration**: The reattach data listener only checks stored data once when `isOpen` changes, which may miss the data if timing is off
+3. **State reset timing**: The useEffect that manages initial state may interfere with reattach restoration
+
+## Solution
+
+### 1. Update App.tsx to pass `caseFolderPath` during reattach
+
+- Store `caseFolderPath` in the reattach data flow
+- Pass it as a prop to `PDFExtractionModal` when opening for reattach
+- Modify the reattach event handler to extract and store the case folder path
+
+### 2. Improve state restoration in PDFExtractionModal
+
+- Add a more robust check for stored reattach data that runs on modal open
+- Ensure the reattach listener runs regardless of timing
+- Add a useEffect that specifically watches for stored data when the modal opens
+- Prevent the initial state useEffect from interfering with reattach restoration
+
+### 3. Ensure data persistence
+
+- Verify that `caseFolderPath` is included in the reattach data sent from DetachedPDFExtraction
+- Ensure the modal properly restores `caseFolderPath` from reattach data
+
+## Files to Modify
+
+1. **[src/App.tsx](src/App.tsx)**: 
+
+- Update reattach event handler to extract and store `caseFolderPath` from reattach data
+- Pass `caseFolderPath` prop to `PDFExtractionModal` component
+
+2. **[src/components/PDFExtractionModal.tsx](src/components/PDFExtractionModal.tsx)**:
+
+- Improve reattach data listener to check stored data more reliably
+- Add useEffect to check for stored data when modal becomes open
+- Ensure state restoration includes `caseFolderPath`
+- Prevent state reset from interfering with reattach restoration
+
+3. **[src/components/DetachedPDFExtraction.tsx](src/components/DetachedPDFExtraction.tsx)**:
+
+- Verify `caseFolderPath` is included in reattach state (already appears to be there)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,9 +54,15 @@ function AppContent() {
   // Listen for reattach data from detached PDF extraction window
   useEffect(() => {
     const handleReattach = (event: any) => {
-      // Open the PDF extraction modal when reattaching
-      console.log('App: Received reattach-pdf-extraction-data event, opening modal');
-      setShowPDFExtraction(true);
+      const data = event.detail;
+      
+      // Only handle reattach if caseFolderPath is absent (home menu usage)
+      // If caseFolderPath is present, ArchivePage will handle it
+      if (data && !data.caseFolderPath) {
+        // Open the PDF extraction modal when reattaching from home menu
+        console.log('App: Received reattach-pdf-extraction-data event without caseFolderPath, opening modal');
+        setShowPDFExtraction(true);
+      }
     };
 
     window.addEventListener('reattach-pdf-extraction-data' as any, handleReattach as EventListener);
@@ -64,8 +70,8 @@ function AppContent() {
     // Also check for stored data on mount
     const checkStoredData = () => {
       const storedData = (window as any).__reattachPdfExtractionData;
-      if (storedData) {
-        console.log('App: Found stored reattach data, opening modal');
+      if (storedData && !storedData.caseFolderPath) {
+        console.log('App: Found stored reattach data without caseFolderPath, opening modal');
         setShowPDFExtraction(true);
       }
     };

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -147,6 +147,7 @@ export function PDFExtractionModal({
       progress: any | null;
       error: string | null;
       statusMessage: string;
+      caseFolderPath?: string | null;
     }>) => {
       const data = event.detail;
       
@@ -181,6 +182,7 @@ export function PDFExtractionModal({
       progress: any | null;
       error: string | null;
       statusMessage: string;
+      caseFolderPath?: string | null;
     }) => {
       console.log('PDFExtractionModal: restoreReattachState called', {
         hasPreviewPage: !!data.previewPage,


### PR DESCRIPTION
This pull request addresses a bug where the PDF to Image Conversion modal loses all extracted pages and state when reattaching from a detached window. The fix ensures that the modal reliably restores its previous state, including the `caseFolderPath`, by improving the state restoration logic and event handling across relevant components.

**Improvements to state restoration and event handling:**

* Updated `App.tsx` to properly handle reattach events by only opening the modal when `caseFolderPath` is absent, ensuring correct context for home menu usage.
* Added a reattach event listener and stored data check in `ArchivePage.tsx` to handle cases where `caseFolderPath` is present, opening the modal and restoring the PDF path as needed for archive usage.
* Enhanced `PDFExtractionModal.tsx` to include `caseFolderPath` in the restored state, ensuring the modal can fully recover its context after reattachment. [[1]](diffhunk://#diff-5c1ea5c931b7680ed2d746cb797f3100ed2be329843a70ade342e33080379bb8R150) [[2]](diffhunk://#diff-5c1ea5c931b7680ed2d746cb797f3100ed2be329843a70ade342e33080379bb8R185)

**Documentation and planning:**

* Added a detailed plan in `.cursor/plans/fix_pdf_extraction_reattach_state_loss_c7420aae.plan.md` outlining the problem analysis, solution steps, and files to modify for fixing PDF extraction reattach state loss.