### PR TITLE
85 thefancynerd i like the way this looks just have a few issues when detaching there is a lot of changes so we may want to get in a call to discuss this branch further in depth

### DIFF
--- a/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
+++ b/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
@@ -4,20 +4,20 @@ overview: The `extractPDFFromArchive` handler currently only saves individual fi
 todos:
   - id: update-extract-zip-types
     content: Update electronAPI.d.ts to add saveToZip parameter to extractPDFFromArchive options
-    status: pending
+    status: completed
   - id: update-extract-zip-backend
     content: Update electron/main.ts extract-pdf-from-archive handler to support ZIP creation when saveToZip is true
-    status: pending
+    status: completed
     dependencies:
       - update-extract-zip-types
   - id: update-modal-zip-option
     content: Update PDFExtractionModal.tsx to pass saveToZip option to extractPDFFromArchive
-    status: pending
+    status: completed
     dependencies:
       - update-extract-zip-types
   - id: update-detached-zip-option
     content: Update DetachedPDFExtraction.tsx to pass saveToZip option to extractPDFFromArchive
-    status: pending
+    status: completed
     dependencies:
       - update-extract-zip-types
 ---

--- a/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
+++ b/.cursor/plans/add_zip_support_to_extractpdffromarchive_handler_64670672.plan.md
@@ -1,0 +1,87 @@
+---
+name: Add ZIP support to extractPDFFromArchive handler
+overview: The `extractPDFFromArchive` handler currently only saves individual files, but when users select "Save to ZIP Folder" from the archive, it should create a ZIP file. We need to add `saveToZip` parameter support to `extractPDFFromArchive` and implement ZIP creation logic similar to the `save-files` handler.
+todos:
+  - id: update-extract-zip-types
+    content: Update electronAPI.d.ts to add saveToZip parameter to extractPDFFromArchive options
+    status: pending
+  - id: update-extract-zip-backend
+    content: Update electron/main.ts extract-pdf-from-archive handler to support ZIP creation when saveToZip is true
+    status: pending
+    dependencies:
+      - update-extract-zip-types
+  - id: update-modal-zip-option
+    content: Update PDFExtractionModal.tsx to pass saveToZip option to extractPDFFromArchive
+    status: pending
+    dependencies:
+      - update-extract-zip-types
+  - id: update-detached-zip-option
+    content: Update DetachedPDFExtraction.tsx to pass saveToZip option to extractPDFFromArchive
+    status: pending
+    dependencies:
+      - update-extract-zip-types
+---
+
+# Add ZIP Support to extractPDFFromArchive Handler
+
+## Problem Analysis
+
+When saving from PDFExtractionModal with `caseFolderPath` (archive case), the code always uses `extractPDFFromArchive`, regardless of the `saveToZip` option. However, `extractPDFFromArchive` doesn't support ZIP files - it only saves individual files. This causes:
+
+- When user checks "Save to ZIP Folder" in archive, files are saved as loose files instead of in a ZIP
+- The `saveToZip` option is ignored when saving to archive
+
+## Solution
+
+### 1. Update Type Definitions
+
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to add `saveToZip` parameter to `extractPDFFromArchive` options
+
+### 2. Update Backend Handler
+
+- Modify [`electron/main.ts`](electron/main.ts) `extract-pdf-from-archive` handler:
+- Accept `saveToZip` parameter in options
+- When `saveToZip` is true, create a ZIP file instead of saving individual files
+- Use JSZip to create the ZIP archive (similar to `save-files` handler)
+- Save the ZIP file in the case folder with the folder name
+- Still create the `.parent-pdf` metadata file for folder positioning
+- When `saveToZip` is false, save individual files as before
+
+### 3. Update Frontend Components
+
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleSave`:
+- Pass `saveToZip` option to `extractPDFFromArchive` when `caseFolderPath` exists
+
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) `handleSave`:
+- Pass `saveToZip` option to `extractPDFFromArchive` when `caseFolderPath` exists
+
+## Implementation Details
+
+### Backend Changes
+
+The `extract-pdf-from-archive` handler should:
+
+1. Accept `saveToZip: boolean` in options
+2. When `saveToZip` is true:
+
+- Create a ZIP file using JSZip
+- Add all extracted pages to the ZIP using the provided file names
+- Save the ZIP file as `${folderName}.zip` in the case folder
+- Create the `.parent-pdf` metadata file to link the ZIP to the parent PDF
+- Optionally save parent PDF inside the ZIP if `saveParentFile` is true
+
+3. When `saveToZip` is false:
+
+- Save individual files as before (existing behavior)
+
+### Frontend Changes
+
+1. Pass `saveToZip` in the options when calling `extractPDFFromArchive`
+2. No other changes needed - the logic already determines when to use `extractPDFFromArchive`
+
+## Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Add saveToZip parameter
+2. [`electron/main.ts`](electron/main.ts) - Add ZIP support to extract-pdf-from-archive handler
+3. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Pass saveToZip option
+4. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Pass saveToZip option

--- a/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
+++ b/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
@@ -4,20 +4,20 @@ overview: "Fix two issues: (1) When saving individual image files (not ZIP) from
 todos:
   - id: update-extract-types
     content: Update electronAPI.d.ts to include fileName in extractedPages array items for extractPDFFromArchive
-    status: pending
+    status: completed
   - id: update-extract-backend
     content: Update electron/main.ts extract-pdf-from-archive handler to accept and use fileName
-    status: pending
+    status: completed
     dependencies:
       - update-extract-types
   - id: update-modal-save-logic
     content: Update PDFExtractionModal.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files), pass fileName, and call onExtractionComplete after save
-    status: pending
+    status: completed
     dependencies:
       - update-extract-types
   - id: update-detached-save-logic
     content: Update DetachedPDFExtraction.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files) and pass fileName
-    status: pending
+    status: completed
     dependencies:
       - update-extract-types
 ---

--- a/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
+++ b/.cursor/plans/fix_archive_folder_refresh_and_positioning_after_pdf_extraction_dae09c51.plan.md
@@ -1,0 +1,94 @@
+---
+name: Fix archive folder refresh and positioning after PDF extraction
+overview: "Fix two issues: (1) When saving individual image files (not ZIP) from PDFExtractionModal with a case folder, use extractPDFFromArchive instead of saveFiles so the folder appears in the archive and is properly linked to the parent PDF. (2) Call onExtractionComplete after saving completes to refresh the case files list immediately. The extractPDFFromArchive handler also needs to be updated to accept fileName to support custom file naming patterns."
+todos:
+  - id: update-extract-types
+    content: Update electronAPI.d.ts to include fileName in extractedPages array items for extractPDFFromArchive
+    status: pending
+  - id: update-extract-backend
+    content: Update electron/main.ts extract-pdf-from-archive handler to accept and use fileName
+    status: pending
+    dependencies:
+      - update-extract-types
+  - id: update-modal-save-logic
+    content: Update PDFExtractionModal.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files), pass fileName, and call onExtractionComplete after save
+    status: pending
+    dependencies:
+      - update-extract-types
+  - id: update-detached-save-logic
+    content: Update DetachedPDFExtraction.tsx to use extractPDFFromArchive when caseFolderPath exists (for individual files) and pass fileName
+    status: pending
+    dependencies:
+      - update-extract-types
+---
+
+# Fix Archive Folder Refresh and Positioning After PDF Extraction
+
+## Problem Analysis
+
+1. **Folder not appearing**: When saving individual image files (not ZIP) from PDFExtractionModal with `caseFolderPath`, the code uses `saveFiles` instead of `extractPDFFromArchive`. This means:
+
+- The folder isn't created in the archive case folder
+- The `.parent-pdf` metadata file isn't created
+- The folder won't appear in the case file listing
+- The folder won't be positioned above the PDF card
+
+2. **No refresh after save**: After saving completes, `onExtractionComplete` is not called, so the files list isn't refreshed and the user must back out and reopen the case to see the new folder.
+
+3. **File naming**: The `extractPDFFromArchive` handler generates file names like `page-${pageNumber}.${extension}`, but we need it to accept custom file names from the frontend to support file naming patterns.
+
+## Solution
+
+### 1. Update Type Definitions
+
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to include `fileName` in `extractedPages` array items for `extractPDFFromArchive`
+
+### 2. Update Backend Handler
+
+- Modify [`electron/main.ts`](electron/main.ts) `extract-pdf-from-archive` handler:
+- Accept `fileName` in `extractedPages` array items
+- Use the provided `fileName` instead of generating it
+- Ensure the `.parent-pdf` metadata file is created (already done, but verify)
+
+### 3. Update Frontend Components
+
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleSave`:
+- When `caseFolderPath` exists, use `extractPDFFromArchive` for both ZIP and individual files (currently only used for ZIP)
+- Pass `fileName` in the `extractedPages` array
+- Call `onExtractionComplete` after saving completes successfully
+
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) `handleSave`:
+- When `caseFolderPath` exists, use `extractPDFFromArchive` for individual files
+- Pass `fileName` in the `extractedPages` array (already done for `saveFiles`)
+
+## Implementation Details
+
+### Logic Flow
+
+When saving from PDFExtractionModal with `caseFolderPath`:
+
+1. If `caseFolderPath` exists:
+
+- Always use `extractPDFFromArchive` (regardless of saveToZip)
+- This ensures the folder appears in the archive and is linked to the parent PDF
+- Note: Currently `extractPDFFromArchive` only saves individual files. ZIP support may need to be added later, but for now we focus on individual files.
+
+2. If `caseFolderPath` doesn't exist:
+
+- Use `saveFiles` as before (for both ZIP and individual files)
+
+3. After save completes:
+
+- Call `onExtractionComplete()` to refresh the files list
+
+### Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Update type definitions for extractPDFFromArchive
+2. [`electron/main.ts`](electron/main.ts) - Update extract-pdf-from-archive handler to accept fileName
+3. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Use extractPDFFromArchive when caseFolderPath exists, call onExtractionComplete
+4. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Use extractPDFFromArchive when caseFolderPath exists
+
+## Notes
+
+- The folder positioning (above PDF card) should work automatically once we use `extractPDFFromArchive` because it creates the `.parent-pdf` metadata file
+- ZIP support in `extractPDFFromArchive` is out of scope for this fix - focus on individual files

--- a/.cursor/plans/fix_detached_window_case_folder_path_reattach_2b8f3c9d.plan.md
+++ b/.cursor/plans/fix_detached_window_case_folder_path_reattach_2b8f3c9d.plan.md
@@ -1,0 +1,46 @@
+# Fix Detached Window Case Folder Path Memory
+
+## Problem Analysis
+
+When detaching the PDF extraction window from an archive case, the `caseFolderPath` is not being passed through the detach/reattach flow. This causes:
+- The detached window doesn't remember which case it came from
+- When saving from the detached window, `caseFolderPath` is null, so it can't save to the archive case folder
+- The detached window can't use `extractPDFFromArchive` because it doesn't know the case path
+
+## Solution
+
+### 1. Update Type Definitions
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to add `caseFolderPath` parameter to both `createPdfExtractionWindow` and `reattachPdfExtraction` options
+
+### 2. Update Frontend Modal
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleDetach`:
+  - Include `caseFolderPath` in the state object passed to `createPdfExtractionWindow`
+
+### 3. Update Backend Handlers
+- Modify [`electron/main.ts`](electron/main.ts) `create-pdf-extraction-window` handler:
+  - Accept `caseFolderPath` parameter in options
+  - Pass `caseFolderPath` to the detached window in the initial data
+
+- Modify [`electron/main.ts`](electron/main.ts) `reattach-pdf-extraction` handler:
+  - Accept `caseFolderPath` parameter in options
+  - Pass `caseFolderPath` to the main window in the reattach data
+
+### 4. Update Detached Window
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx):
+  - Change `caseFolderPath` from hardcoded `null` to state that can be set
+  - Receive `caseFolderPath` from initial data when window loads
+  - Include `caseFolderPath` in the state when reattaching
+
+## Implementation Details
+
+The flow should be:
+1. Modal detaches → includes `caseFolderPath` in state → backend stores it → detached window receives it
+2. Detached window saves → uses `caseFolderPath` for archive saves
+3. Detached window reattaches → includes `caseFolderPath` in reattach state → backend passes it to main window
+
+## Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Add caseFolderPath parameter
+2. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Include caseFolderPath when detaching
+3. [`electron/main.ts`](electron/main.ts) - Pass caseFolderPath through detach/reattach handlers
+4. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Store and use caseFolderPath

--- a/.cursor/plans/fix_pdf_extraction_image_saving_bug_af52ec67.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_image_saving_bug_af52ec67.plan.md
@@ -1,0 +1,64 @@
+---
+name: ""
+overview: ""
+todos: []
+---
+
+# Fix PDF Extraction Image Saving Bug
+
+## Problem
+
+The `save-files` IPC handler in [`electron/main.ts`](electron/main.ts) (lines 543-626) does not properly handle both save modes based on the `saveToZip` flag. Currently:
+
+- **When `saveToZip` is true**: Images are saved inside a ZIP file ✅ (lines 582-620)
+- **When `saveToZip` is false**: Only the parent PDF is saved (if requested), but **extracted page images are NOT saved** ❌
+
+The handler has no `else` branch or separate code block for the non-ZIP case. This is a missing integration of the `saveToZip` flag - the code doesn't handle both branches properly.
+
+This bug affects PDF extraction from both:
+
+- The home screen (`DetachedPDFExtraction`, `PDFExtractionModal`)
+- Within the Vault on PDFs in case files (when using `saveFiles` API)
+
+Note: The `extract-pdf-from-archive` handler (lines 2683-2748) correctly saves individual images, but the `save-files` handler is missing this logic.
+
+## Solution
+
+Add an `else` branch (or separate conditional block) after the ZIP saving block to save individual image files when `saveToZip` is false. The implementation should match the pattern used in the `extract-pdf-from-archive` handler (lines 2717-2742).
+
+## Changes Required
+
+### File: `electron/main.ts`
+
+**Location:** After line 620 (after the `if (saveToZip && folderName)` block), add an `else` branch for when `saveToZip` is false.
+
+**Implementation details:**
+
+- Check if `saveToZip` is false (or use an `else` block)
+- Iterate through `extractedPages` array
+- For each page:
+  - Parse the image format from the base64 data URL (PNG/JPEG) - same pattern as lines 594-610
+  - Convert base64 string to Buffer
+  - Write each image file to `saveDirectory` with filename pattern: `page-${pageNumber}.${extension}`
+  - Add success message to `results` array: `Page ${pageNumber} saved: ${imagePath}`
+
+This should mirror the implementation in `extract-pdf-from-archive` handler (lines 2718-2742), which correctly saves individual image files.
+
+**Code structure should become:**
+
+```typescript
+// Save parent PDF file if requested
+if (saveParentFile && parentFilePath) {
+  // ... existing code ...
+}
+
+// Save to ZIP if requested
+if (saveToZip && folderName) {
+  // ... existing ZIP code ...
+} else {
+  // NEW: Save individual image files when NOT saving to ZIP
+  for (const page of extractedPages) {
+    // ... save individual image files ...
+  }
+}
+```

--- a/.cursor/plans/fix_pdf_extraction_reattach_state_loss_c7420aae.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_reattach_state_loss_c7420aae.plan.md
@@ -1,0 +1,53 @@
+---
+name: Fix PDF Extraction Reattach State Loss
+overview: Fix the bug where the PDF to Image Conversion modal loses all extracted pages and state when reattaching from a detached window. The issue is caused by a race condition in state restoration and missing caseFolderPath prop handling.
+todos: []
+---
+
+# Fix PDF Extraction Reattach State Loss
+
+## Problem Analysis
+
+When reattaching a detached PDF extraction window after completion, the modal opens but all extracted pages and state are lost. The issue stems from:
+
+1. **Missing `caseFolderPath` prop**: When App.tsx opens the modal for reattach, it doesn't pass the `caseFolderPath` prop that the modal needs
+2. **Race condition in state restoration**: The reattach data listener only checks stored data once when `isOpen` changes, which may miss the data if timing is off
+3. **State reset timing**: The useEffect that manages initial state may interfere with reattach restoration
+
+## Solution
+
+### 1. Update App.tsx to pass `caseFolderPath` during reattach
+
+- Store `caseFolderPath` in the reattach data flow
+- Pass it as a prop to `PDFExtractionModal` when opening for reattach
+- Modify the reattach event handler to extract and store the case folder path
+
+### 2. Improve state restoration in PDFExtractionModal
+
+- Add a more robust check for stored reattach data that runs on modal open
+- Ensure the reattach listener runs regardless of timing
+- Add a useEffect that specifically watches for stored data when the modal opens
+- Prevent the initial state useEffect from interfering with reattach restoration
+
+### 3. Ensure data persistence
+
+- Verify that `caseFolderPath` is included in the reattach data sent from DetachedPDFExtraction
+- Ensure the modal properly restores `caseFolderPath` from reattach data
+
+## Files to Modify
+
+1. **[src/App.tsx](src/App.tsx)**: 
+
+- Update reattach event handler to extract and store `caseFolderPath` from reattach data
+- Pass `caseFolderPath` prop to `PDFExtractionModal` component
+
+2. **[src/components/PDFExtractionModal.tsx](src/components/PDFExtractionModal.tsx)**:
+
+- Improve reattach data listener to check stored data more reliably
+- Add useEffect to check for stored data when modal becomes open
+- Ensure state restoration includes `caseFolderPath`
+- Prevent state reset from interfering with reattach restoration
+
+3. **[src/components/DetachedPDFExtraction.tsx](src/components/DetachedPDFExtraction.tsx)**:
+
+- Verify `caseFolderPath` is included in reattach state (already appears to be there)

--- a/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
@@ -1,0 +1,107 @@
+---
+name: Fix PDF extraction save bug and require folder names
+overview: Fix the bug where saving individual image files (when both options are unchecked) doesn't work, and make folder names a requirement for all save operations. The backend `save-files` handler is missing the logic to save individual image files, and the UI needs to require folder names for both loose file and ZIP saves.
+todos:
+  - id: update-types
+    content: Update electronAPI.d.ts to include fileName in extractedPages array items for save-files handler
+    status: pending
+  - id: update-backend-save
+    content: Update electron/main.ts save-files handler to save individual image files when saveToZip is false, and always require folderName
+    status: pending
+    dependencies:
+      - update-types
+  - id: update-save-options-ui
+    content: Update PDFExtractionSaveOptions.tsx to always show folder name field and require it for all save operations
+    status: pending
+  - id: update-modal-handler
+    content: Update PDFExtractionModal.tsx handleSave to pass fileName in extractedPages array
+    status: pending
+    dependencies:
+      - update-types
+  - id: update-detached-handler
+    content: Update DetachedPDFExtraction.tsx handleSave to pass fileName in extractedPages array
+    status: pending
+    dependencies:
+      - update-types
+---
+
+# Fix PDF Extraction Save Bug and Require Folder Names
+
+## Problem Analysis
+
+1. **Bug**: In [`electron/main.ts`](electron/main.ts) (lines 542-626), the `save-files` handler only handles:
+
+- Saving parent PDF when `saveParentFile` is true (lines 569-580)
+- Saving to ZIP when `saveToZip && folderName` is true (lines 582-620)
+- **Missing**: Logic to save individual image files when `saveToZip` is false
+
+This causes the handler to return success with empty results when both options are unchecked.
+
+2. **Missing file names**: The frontend components generate file names using the naming pattern, but only pass `pageNumber` and `imageData` to the backend. The backend needs file names to save individual files.
+
+3. **Folder name requirement**: Currently, folder names are only required when `saveToZip` is true. The user wants folder names required for all save operations:
+
+- When saving as loose files: create a subfolder with that name
+- When saving as ZIP: use that name for the ZIP file (already works)
+
+## Solution
+
+### 1. Update Type Definitions
+
+- Modify [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) to include `fileName` in `extractedPages` array items
+
+### 2. Update Backend Handler
+
+- Modify [`electron/main.ts`](electron/main.ts) `save-files` handler:
+- Accept `fileName` in `extractedPages` array items (update type signature)
+- When `saveToZip` is false, save individual image files to a subfolder (using `folderName`) in the save directory
+- Use the provided file names from the frontend
+- Handle image format detection (PNG/JPEG) from data URLs
+
+### 3. Update Frontend Components
+
+- Modify [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) `handleSave`:
+- Pass `fileName` along with `pageNumber` and `imageData` to the backend
+
+- Modify [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) `handleSave`:
+- Pass `fileName` along with `pageNumber` and `imageData` to the backend
+
+### 4. Update Save Options UI
+
+- Modify [`src/components/PDFExtractionSaveOptions.tsx`](src/components/PDFExtractionSaveOptions.tsx):
+- Always show the folder name input field (remove conditional rendering)
+- Always require folder name (update validation in `handleConfirm`)
+- Update button disabled condition to always require folder name
+- Update error messages to reflect that folder name is always required
+- Update the description text to indicate folder names are used for subfolders (loose files) or ZIP files
+
+## Implementation Details
+
+### Backend Changes
+
+The `save-files` handler should:
+
+1. Always require `folderName` (validate it's provided and not empty)
+2. When `saveToZip` is false:
+
+- Create a subfolder in `saveDirectory` using `folderName`
+- Save each image file to that subfolder using the provided `fileName`
+- Detect image format from data URL (PNG/JPEG)
+
+3. When `saveToZip` is true (existing logic):
+
+- Use `folderName` for the ZIP file name (already works)
+
+### Frontend Changes
+
+1. Pass `fileName` in the `extractedPages` array to the backend
+2. Always show and require folder name input
+3. Update validation to require folder name for all save operations
+
+## Files to Modify
+
+1. [`src/types/electronAPI.d.ts`](src/types/electronAPI.d.ts) - Update type definitions
+2. [`electron/main.ts`](electron/main.ts) - Add logic to save individual files and require folder name
+3. [`src/components/PDFExtractionSaveOptions.tsx`](src/components/PDFExtractionSaveOptions.tsx) - Always show and require folder name
+4. [`src/components/PDFExtractionModal.tsx`](src/components/PDFExtractionModal.tsx) - Pass file names to backend
+5. [`src/components/DetachedPDFExtraction.tsx`](src/components/DetachedPDFExtraction.tsx) - Pass file names to backend

--- a/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
+++ b/.cursor/plans/fix_pdf_extraction_save_bug_and_require_folder_names_84288ecc.plan.md
@@ -4,23 +4,23 @@ overview: Fix the bug where saving individual image files (when both options are
 todos:
   - id: update-types
     content: Update electronAPI.d.ts to include fileName in extractedPages array items for save-files handler
-    status: pending
+    status: completed
   - id: update-backend-save
     content: Update electron/main.ts save-files handler to save individual image files when saveToZip is false, and always require folderName
-    status: pending
+    status: completed
     dependencies:
       - update-types
   - id: update-save-options-ui
     content: Update PDFExtractionSaveOptions.tsx to always show folder name field and require it for all save operations
-    status: pending
+    status: completed
   - id: update-modal-handler
     content: Update PDFExtractionModal.tsx handleSave to pass fileName in extractedPages array
-    status: pending
+    status: completed
     dependencies:
       - update-types
   - id: update-detached-handler
     content: Update DetachedPDFExtraction.tsx handleSave to pass fileName in extractedPages array
-    status: pending
+    status: completed
     dependencies:
       - update-types
 ---

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2074,13 +2074,14 @@ ipcMain.handle('list-case-files', async (event, casePath: string) => {
     const groupedItems: Array<typeof files[0] | typeof folders[0]> = [];
     
     // Add folders and their PDFs in alphabetical PDF order
+    // CRITICAL: Folders MUST come before their PDF in the array for frontend grouping to work
     // This ensures folders always appear above their associated PDFs
     for (const pdf of pdfFiles) {
       const relatedFolders = pdfToFoldersMap.get(pdf.name) || [];
       // Add folders above the PDF (folders are already sorted alphabetically)
-      groupedItems.push(...relatedFolders);
+      groupedItems.push(...relatedFolders);  // ← Folders first
       // Add the PDF
-      groupedItems.push(pdf);
+      groupedItems.push(pdf);  // ← Then PDF
     }
     
     // Add orphaned folders (folders without a matching PDF) after all PDFs

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3617,6 +3617,7 @@ ipcMain.handle('create-pdf-extraction-window', async (event, options: {
   progress: any | null;
   error: string | null;
   statusMessage: string;
+  caseFolderPath?: string | null;
 }) => {
   try {
     logger.info('create-pdf-extraction-window handler called', {
@@ -3699,7 +3700,8 @@ ipcMain.handle('create-pdf-extraction-window', async (event, options: {
               isExtracting: ${JSON.stringify(options.isExtracting)},
               progress: ${options.progress ? JSON.stringify(options.progress) : 'null'},
               error: ${options.error ? JSON.stringify(options.error) : 'null'},
-              statusMessage: ${JSON.stringify(options.statusMessage || '')}
+              statusMessage: ${JSON.stringify(options.statusMessage || '')},
+              caseFolderPath: ${options.caseFolderPath ? JSON.stringify(options.caseFolderPath) : 'null'}
             };
             console.log('Main process: Dispatching pdf-extraction-data event', data);
             // Store data in case listener isn't ready yet
@@ -3742,6 +3744,7 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
   progress: any | null;
   error: string | null;
   statusMessage: string;
+  caseFolderPath?: string | null;
 }) => {
   try {
     // Get the window that sent the request (the detached extraction window)
@@ -3759,7 +3762,8 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
         isExtracting: options.isExtracting,
         progress: options.progress,
         error: options.error,
-        statusMessage: options.statusMessage || ''
+        statusMessage: options.statusMessage || '',
+        caseFolderPath: options.caseFolderPath || null
       };
 
       logger.info('Reattaching PDF extraction window', {
@@ -3767,6 +3771,7 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
         extractedPagesCount: reattachData.extractedPages.length,
         selectedPagesCount: reattachData.selectedPages.length,
         hasPreviewPage: !!reattachData.previewPage,
+        hasCaseFolderPath: !!reattachData.caseFolderPath,
       });
 
       // Store data globally first so modal can access it when it mounts
@@ -3782,7 +3787,8 @@ ipcMain.handle('reattach-pdf-extraction', async (event, options: {
             isExtracting: ${JSON.stringify(reattachData.isExtracting)},
             progress: ${reattachData.progress ? JSON.stringify(reattachData.progress) : 'null'},
             error: ${reattachData.error ? JSON.stringify(reattachData.error) : 'null'},
-            statusMessage: ${JSON.stringify(reattachData.statusMessage)}
+            statusMessage: ${JSON.stringify(reattachData.statusMessage)},
+            caseFolderPath: ${reattachData.caseFolderPath ? JSON.stringify(reattachData.caseFolderPath) : 'null'}
           };
           // Store data globally for modal to access when it mounts
           window.__reattachPdfExtractionData = data;

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,8 @@
         "wait-on": "^7.2.0"
       },
       "engines": {
-        "node": ">=20.0.0 <21.0.0",
-        "npm": ">=9.0.0"
+        "node": "24.12.0",
+        "npm": ">=11.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -162,6 +162,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -537,6 +538,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -560,6 +562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -866,9 +869,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1284,9 +1287,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2341,6 +2344,32 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2405,9 +2434,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
       "cpu": [
         "arm"
       ],
@@ -2419,9 +2448,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
       "cpu": [
         "arm64"
       ],
@@ -2433,9 +2462,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
       "cpu": [
         "arm64"
       ],
@@ -2447,9 +2476,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
       "cpu": [
         "x64"
       ],
@@ -2461,9 +2490,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
       "cpu": [
         "arm64"
       ],
@@ -2475,9 +2504,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
       "cpu": [
         "x64"
       ],
@@ -2489,9 +2518,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
       "cpu": [
         "arm"
       ],
@@ -2503,9 +2532,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
       "cpu": [
         "arm"
       ],
@@ -2517,9 +2546,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
       "cpu": [
         "arm64"
       ],
@@ -2531,9 +2560,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
       "cpu": [
         "arm64"
       ],
@@ -2545,9 +2574,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
       "cpu": [
         "loong64"
       ],
@@ -2559,9 +2602,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
       "cpu": [
         "ppc64"
       ],
@@ -2573,9 +2630,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
       "cpu": [
         "riscv64"
       ],
@@ -2587,9 +2644,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
       "cpu": [
         "riscv64"
       ],
@@ -2601,9 +2658,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
       "cpu": [
         "s390x"
       ],
@@ -2615,9 +2672,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
       "cpu": [
         "x64"
       ],
@@ -2629,9 +2686,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
       "cpu": [
         "x64"
       ],
@@ -2642,10 +2699,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
       "cpu": [
         "arm64"
       ],
@@ -2657,9 +2728,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
       "cpu": [
         "arm64"
       ],
@@ -2671,9 +2742,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
       "cpu": [
         "ia32"
       ],
@@ -2685,9 +2756,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
       "cpu": [
         "x64"
       ],
@@ -2699,9 +2770,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
       "cpu": [
         "x64"
       ],
@@ -3014,9 +3085,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
-      "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
+      "version": "20.19.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.28.tgz",
+      "integrity": "sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3048,6 +3119,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3151,6 +3223,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3491,6 +3564,7 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -3588,6 +3662,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3637,6 +3712,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3819,7 +3895,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -3839,7 +3914,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -3856,13 +3930,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3878,8 +3958,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3887,7 +3966,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -4044,9 +4122,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.22",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-      "integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
+      "version": "10.4.23",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+      "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
       "dev": true,
       "funding": [
         {
@@ -4064,10 +4142,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
-        "caniuse-lite": "^1.0.30001754",
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001760",
         "fraction.js": "^5.3.4",
-        "normalize-range": "^0.1.2",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -4155,9 +4232,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.5.tgz",
-      "integrity": "sha512-D5vIoztZOq1XM54LUdttJVc96ggEsIfju2JBvht06pSzpckp3C7HReun67Bghzrtdsq9XdMGbSSB3v3GhMNmAA==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4213,7 +4290,6 @@
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4296,6 +4372,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4577,9 +4654,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001760",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-      "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
       "dev": true,
       "funding": [
         {
@@ -4899,7 +4976,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -5047,7 +5123,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -5061,7 +5136,6 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -5218,43 +5292,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/data-urls/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -5371,13 +5408,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/deep-equal/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5775,7 +5805,6 @@
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -5789,7 +5818,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5805,7 +5833,6 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -5819,7 +5846,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -6037,13 +6063,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6157,6 +6176,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6221,9 +6241,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.24.tgz",
-      "integrity": "sha512-nLHIW7TEq3aLrEYWpVaJ1dRgFR+wLDPN8e8FpYAql/bMV2oBEfC37K0gLEGgv9fy66juNShSMV8OkTqzltcG/w==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6303,9 +6323,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6443,15 +6463,14 @@
       }
     },
     "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6505,9 +6524,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6766,8 +6785,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -7979,9 +7997,10 @@
       }
     },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -8009,7 +8028,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -8045,22 +8063,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -8218,6 +8220,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8348,43 +8351,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/jsdom/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -8472,16 +8438,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/jsprim/node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/jsprim/node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -8508,6 +8464,12 @@
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
       }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -8562,7 +8524,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -8570,13 +8531,19 @@
         "node": ">= 0.6.3"
       }
     },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8592,8 +8559,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -8601,7 +8567,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8627,11 +8592,10 @@
       "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.116.tgz",
-      "integrity": "sha512-4zsosjzmt33rx5XjmFVYUAeLNh+BTeDTiwGdLt4muxiir2btsc60Nal0EvkvDRizg+pnlK1q+BtYi7M+d4eStw==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -8762,32 +8726,28 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -8801,8 +8761,7 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -8888,29 +8847,19 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/matcher": {
@@ -9254,6 +9203,31 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -9281,16 +9255,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9903,6 +9867,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10243,6 +10208,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10255,6 +10221,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10372,7 +10339,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -10383,7 +10349,6 @@
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10669,9 +10634,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10685,28 +10650,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -10808,11 +10776,14 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -11575,9 +11546,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
-      "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11636,7 +11607,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -11828,6 +11798,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11942,11 +11913,17 @@
       }
     },
     "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -12056,6 +12033,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12065,9 +12043,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.2.tgz",
+      "integrity": "sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -12089,9 +12067,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
-      "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -12199,6 +12177,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12282,6 +12261,7 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -12376,16 +12356,20 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12406,14 +12390,17 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -12575,9 +12562,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12735,9 +12722,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.28",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.28.tgz",
-      "integrity": "sha512-EgnDOXs8+hBVm6mq3/S89Kiwzh5JRbn7w2wXwbrMRyKy/8dOFsLvuIfC+x19ZdtaDc0tA9rQmdZzbqqNHG44wA==",
+      "version": "13.6.29",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
+      "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12771,7 +12758,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -12787,7 +12773,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "dist-electron/electron/main.cjs",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0 <21.0.0",
-    "npm": ">=9.0.0"
+    "node": "24.12.0",
+    "npm": ">=11.6.2"
   },
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,9 +54,15 @@ function AppContent() {
   // Listen for reattach data from detached PDF extraction window
   useEffect(() => {
     const handleReattach = (event: any) => {
-      // Open the PDF extraction modal when reattaching
-      console.log('App: Received reattach-pdf-extraction-data event, opening modal');
-      setShowPDFExtraction(true);
+      const data = event.detail;
+      
+      // Only handle reattach if caseFolderPath is absent (home menu usage)
+      // If caseFolderPath is present, ArchivePage will handle it
+      if (data && !data.caseFolderPath) {
+        // Open the PDF extraction modal when reattaching from home menu
+        console.log('App: Received reattach-pdf-extraction-data event without caseFolderPath, opening modal');
+        setShowPDFExtraction(true);
+      }
     };
 
     window.addEventListener('reattach-pdf-extraction-data' as any, handleReattach as EventListener);
@@ -64,8 +70,8 @@ function AppContent() {
     // Also check for stored data on mount
     const checkStoredData = () => {
       const storedData = (window as any).__reattachPdfExtractionData;
-      if (storedData) {
-        console.log('App: Found stored reattach data, opening modal');
+      if (storedData && !storedData.caseFolderPath) {
+        console.log('App: Found stored reattach data without caseFolderPath, opening modal');
         setShowPDFExtraction(true);
       }
     };

--- a/src/components/Archive/ArchivePage.tsx
+++ b/src/components/Archive/ArchivePage.tsx
@@ -1336,17 +1336,16 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                     const groupedItems: Array<{ type: 'group' | 'single'; items: ArchiveFile[] }> = [];
                     const processedPaths = new Set<string>();
 
-                    // Build a map of PDF paths to their folders (for quick lookup)
+                    // Build complete map first (all folders for all PDFs)
                     const pdfToFoldersMap = new Map<string, ArchiveFile[]>();
                     const pdfFiles = files.filter(f => !f.isFolder && f.type === 'pdf');
 
+                    // First pass: Collect ALL folders for each PDF
                     files.forEach((item) => {
                       if (item.isFolder && item.parentPdfName) {
-                        // Find the PDF this folder belongs to (case-insensitive match)
                         const associatedPdf = pdfFiles.find(pdf =>
                           pdf.name.toLowerCase() === item.parentPdfName!.toLowerCase()
                         );
-
                         if (associatedPdf) {
                           const pdfKey = associatedPdf.path;
                           if (!pdfToFoldersMap.has(pdfKey)) {
@@ -1357,59 +1356,27 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                       }
                     });
 
-                    // Process items in backend order to maintain sorting
+                    // Second pass: Create groups in backend order
+                    // Process PDFs first (which have folders before them in backend order)
+                    // This ensures all folders for a PDF are collected before creating the group
                     files.forEach((item) => {
                       if (processedPaths.has(item.path)) return;
 
-                      if (item.isFolder && item.parentPdfName) {
-                        // Find the PDF this folder belongs to
-                        const associatedPdf = pdfFiles.find(pdf =>
-                          pdf.name.toLowerCase() === item.parentPdfName!.toLowerCase() &&
-                          !processedPaths.has(pdf.path)
-                        );
-
-                        if (associatedPdf) {
-                          // Get all folders for this PDF (maintain order from backend)
-                          const allFoldersForPdf = pdfToFoldersMap.get(associatedPdf.path) || [];
-                          // Sort folders by their position in the original array to maintain backend order
-                          const sortedFolders = allFoldersForPdf.sort((a, b) => {
-                            const indexA = files.findIndex(f => f.path === a.path);
-                            const indexB = files.findIndex(f => f.path === b.path);
-                            return indexA - indexB;
-                          });
-
-                          // Group all folders with their PDF (folders first, then PDF)
-                          groupedItems.push({
-                            type: 'group',
-                            items: [...sortedFolders, associatedPdf]
-                          });
-
-                          // Mark all as processed
-                          sortedFolders.forEach(folder => processedPaths.add(folder.path));
-                          processedPaths.add(associatedPdf.path);
-                        } else {
-                          // Folder without associated PDF found - render as single
-                          groupedItems.push({
-                            type: 'single',
-                            items: [item]
-                          });
-                          processedPaths.add(item.path);
-                        }
-                      } else if (item.type === 'pdf' && !processedPaths.has(item.path)) {
+                      if (item.type === 'pdf' && !processedPaths.has(item.path)) {
                         // Check if this PDF has unprocessed folders
                         const foldersForPdf = (pdfToFoldersMap.get(item.path) || []).filter(
                           folder => !processedPaths.has(folder.path)
                         );
 
                         if (foldersForPdf.length > 0) {
-                          // Sort folders by their position in the original array
+                          // Sort folders by backend order (their position in the original array)
                           const sortedFolders = foldersForPdf.sort((a, b) => {
                             const indexA = files.findIndex(f => f.path === a.path);
                             const indexB = files.findIndex(f => f.path === b.path);
                             return indexA - indexB;
                           });
 
-                          // Group folders with this PDF
+                          // Group: folders first, then PDF
                           groupedItems.push({
                             type: 'group',
                             items: [...sortedFolders, item]
@@ -1418,25 +1385,28 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                           processedPaths.add(item.path);
                         } else {
                           // Standalone PDF
-                          groupedItems.push({
-                            type: 'single',
-                            items: [item]
-                          });
+                          groupedItems.push({ type: 'single', items: [item] });
                           processedPaths.add(item.path);
                         }
+                      } else if (item.isFolder && item.parentPdfName) {
+                        // Folder with parentPdfName but PDF not found or already processed
+                        // This shouldn't happen if backend ordering is correct, but handle gracefully
+                        const associatedPdf = pdfFiles.find(pdf =>
+                          pdf.name.toLowerCase() === item.parentPdfName!.toLowerCase()
+                        );
+                        if (!associatedPdf || processedPaths.has(associatedPdf.path)) {
+                          // Orphaned folder or PDF already grouped - render as single
+                          groupedItems.push({ type: 'single', items: [item] });
+                          processedPaths.add(item.path);
+                        }
+                        // If PDF exists and not processed, it will be handled when we reach the PDF
+                      } else if (item.isFolder && !item.parentPdfName) {
+                        // Regular folder without parent PDF
+                        groupedItems.push({ type: 'single', items: [item] });
+                        processedPaths.add(item.path);
                       } else if (!item.isFolder && item.type !== 'pdf') {
                         // Non-PDF file
-                        groupedItems.push({
-                          type: 'single',
-                          items: [item]
-                        });
-                        processedPaths.add(item.path);
-                      } else if (item.isFolder && !item.parentPdfName) {
-                        // Folder without parentPdfName metadata
-                        groupedItems.push({
-                          type: 'single',
-                          items: [item]
-                        });
+                        groupedItems.push({ type: 'single', items: [item] });
                         processedPaths.add(item.path);
                       }
                     });

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -270,6 +270,7 @@ export function DetachedPDFExtraction() {
           casePath: caseFolderPath,
           folderName: saveOptions.folderName,
           saveParentFile: saveOptions.saveParentFile,
+          saveToZip: saveOptions.saveToZip,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -19,6 +19,7 @@ interface PdfExtractionState {
   progress: any | null;
   error: string | null;
   statusMessage: string;
+  caseFolderPath?: string | null;
 }
 
 const DEFAULT_SETTINGS: ConversionSettings = {
@@ -39,7 +40,7 @@ export function DetachedPDFExtraction() {
   const [previewPage, setPreviewPage] = useState<ExtractedPage | null>(null);
   const [totalPages, setTotalPages] = useState(0);
   const [isReattaching, setIsReattaching] = useState(false);
-  const [caseFolderPath] = useState<string | null>(null);
+  const [caseFolderPath, setCaseFolderPath] = useState<string | null>(null);
 
   // Local state for extraction when detaching during extraction
   const [localExtractedPages, setLocalExtractedPages] = useState<ExtractedPage[]>([]);
@@ -77,6 +78,9 @@ export function DetachedPDFExtraction() {
       }
       if (data.showSettings !== undefined) {
         setShowSettings(data.showSettings);
+      }
+      if (data.caseFolderPath !== undefined) {
+        setCaseFolderPath(data.caseFolderPath || null);
       }
       if (data.extractedPages && data.extractedPages.length > 0) {
         setLocalExtractedPages(data.extractedPages);
@@ -374,6 +378,7 @@ export function DetachedPDFExtraction() {
         progress: finalProgress,
         error: finalError,
         statusMessage: finalStatusMessage,
+        caseFolderPath: caseFolderPath || null,
       };
 
       console.log('DetachedPDFExtraction: Reattaching with state', {

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -232,7 +232,7 @@ export function DetachedPDFExtraction() {
 
   const handleSave = async (saveOptions: {
     saveDirectory: string;
-    folderName?: string;
+    folderName: string;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -263,7 +263,7 @@ export function DetachedPDFExtraction() {
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
-      if (saveOptions.saveToZip && saveOptions.folderName) {
+      if (saveOptions.saveToZip) {
         if (caseFolderPath) {
           await window.electronAPI.extractPDFFromArchive({
             pdfPath: pdfPath!,
@@ -286,6 +286,7 @@ export function DetachedPDFExtraction() {
             extractedPages: pagesWithNames.map((p) => ({
               pageNumber: p.pageNumber,
               imageData: p.imageData,
+              fileName: p.fileName,
             })),
           });
           toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
@@ -295,10 +296,12 @@ export function DetachedPDFExtraction() {
           saveDirectory: saveOptions.saveDirectory,
           saveParentFile: saveOptions.saveParentFile,
           saveToZip: false,
+          folderName: saveOptions.folderName,
           parentFilePath: pdfPath!,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,
+            fileName: p.fileName,
           })),
         });
         toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -263,20 +263,23 @@ export function DetachedPDFExtraction() {
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
-      if (saveOptions.saveToZip) {
-        if (caseFolderPath) {
-          await window.electronAPI.extractPDFFromArchive({
-            pdfPath: pdfPath!,
-            casePath: caseFolderPath,
-            folderName: saveOptions.folderName,
-            saveParentFile: saveOptions.saveParentFile,
-            extractedPages: pagesWithNames.map((p) => ({
-              pageNumber: p.pageNumber,
-              imageData: p.imageData,
-            })),
-          });
-          toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''} to archive`);
-        } else {
+      if (caseFolderPath) {
+        // Save to archive case folder (always use extractPDFFromArchive for archive)
+        await window.electronAPI.extractPDFFromArchive({
+          pdfPath: pdfPath!,
+          casePath: caseFolderPath,
+          folderName: saveOptions.folderName,
+          saveParentFile: saveOptions.saveParentFile,
+          extractedPages: pagesWithNames.map((p) => ({
+            pageNumber: p.pageNumber,
+            imageData: p.imageData,
+            fileName: p.fileName,
+          })),
+        });
+        toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''} to archive`);
+      } else {
+        // Save to regular directory
+        if (saveOptions.saveToZip) {
           await window.electronAPI.saveFiles({
             saveDirectory: saveOptions.saveDirectory,
             saveParentFile: saveOptions.saveParentFile,
@@ -290,21 +293,21 @@ export function DetachedPDFExtraction() {
             })),
           });
           toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
+        } else {
+          await window.electronAPI.saveFiles({
+            saveDirectory: saveOptions.saveDirectory,
+            saveParentFile: saveOptions.saveParentFile,
+            saveToZip: false,
+            folderName: saveOptions.folderName,
+            parentFilePath: pdfPath!,
+            extractedPages: pagesWithNames.map((p) => ({
+              pageNumber: p.pageNumber,
+              imageData: p.imageData,
+              fileName: p.fileName,
+            })),
+          });
+          toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
         }
-      } else {
-        await window.electronAPI.saveFiles({
-          saveDirectory: saveOptions.saveDirectory,
-          saveParentFile: saveOptions.saveParentFile,
-          saveToZip: false,
-          folderName: saveOptions.folderName,
-          parentFilePath: pdfPath!,
-          extractedPages: pagesWithNames.map((p) => ({
-            pageNumber: p.pageNumber,
-            imageData: p.imageData,
-            fileName: p.fileName,
-          })),
-        });
-        toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
       }
 
       setShowSaveDialog(false);

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -371,6 +371,7 @@ export function PDFExtractionModal({
           casePath: caseFolderPath,
           folderName: saveOptions.folderName,
           saveParentFile: saveOptions.saveParentFile,
+          saveToZip: saveOptions.saveToZip,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -147,6 +147,7 @@ export function PDFExtractionModal({
       progress: any | null;
       error: string | null;
       statusMessage: string;
+      caseFolderPath?: string | null;
     }>) => {
       const data = event.detail;
       
@@ -181,6 +182,7 @@ export function PDFExtractionModal({
       progress: any | null;
       error: string | null;
       statusMessage: string;
+      caseFolderPath?: string | null;
     }) => {
       console.log('PDFExtractionModal: restoreReattachState called', {
         hasPreviewPage: !!data.previewPage,

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -479,6 +479,7 @@ export function PDFExtractionModal({
         progress: progress || null,
         error: error || null,
         statusMessage,
+        caseFolderPath: caseFolderPath || null,
       };
 
       console.log('PDFExtractionModal: Detaching with state', {

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -332,7 +332,7 @@ export function PDFExtractionModal({
 
   const handleSave = async (saveOptions: {
     saveDirectory: string;
-    folderName?: string;
+    folderName: string;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -364,7 +364,7 @@ export function PDFExtractionModal({
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
-      if (saveOptions.saveToZip && saveOptions.folderName) {
+      if (saveOptions.saveToZip) {
         // Save to ZIP folder in archive
         if (caseFolderPath) {
           await window.electronAPI.extractPDFFromArchive({
@@ -389,6 +389,7 @@ export function PDFExtractionModal({
             extractedPages: pagesWithNames.map((p) => ({
               pageNumber: p.pageNumber,
               imageData: p.imageData,
+              fileName: p.fileName,
             })),
           });
           toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
@@ -399,10 +400,12 @@ export function PDFExtractionModal({
           saveDirectory: saveOptions.saveDirectory,
           saveParentFile: saveOptions.saveParentFile,
           saveToZip: false,
+          folderName: saveOptions.folderName,
           parentFilePath: pdfPath!,
           extractedPages: pagesWithNames.map((p) => ({
             pageNumber: p.pageNumber,
             imageData: p.imageData,
+            fileName: p.fileName,
           })),
         });
         toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);

--- a/src/components/PDFExtractionSaveOptions.tsx
+++ b/src/components/PDFExtractionSaveOptions.tsx
@@ -7,7 +7,7 @@ interface PDFExtractionSaveOptionsProps {
   onClose: () => void;
   onConfirm: (options: {
     saveDirectory: string;
-    folderName?: string;
+    folderName: string;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -57,9 +57,9 @@ export function PDFExtractionSaveOptions({
       return;
     }
 
-    // Validate folder name when saveToZip is true
-    if (saveToZip && !folderName.trim()) {
-      setFolderNameError('Folder Name is required when saving to ZIP folder');
+    // Always validate folder name
+    if (!folderName.trim()) {
+      setFolderNameError('Folder name is required');
       return;
     }
 
@@ -67,7 +67,7 @@ export function PDFExtractionSaveOptions({
 
     onConfirm({
       saveDirectory,
-      folderName: saveToZip ? folderName : undefined,
+      folderName: folderName.trim(),
       saveParentFile,
       saveToZip,
       fileNamingPattern: finalPattern,
@@ -179,12 +179,7 @@ export function PDFExtractionSaveOptions({
                 <input
                   type="checkbox"
                   checked={saveToZip}
-                  onChange={(e) => {
-                    setSaveToZip(e.target.checked);
-                    if (!e.target.checked && folderNameError) {
-                      setFolderNameError(null);
-                    }
-                  }}
+                  onChange={(e) => setSaveToZip(e.target.checked)}
                   className="w-5 h-5 rounded border-gray-600 text-cyber-purple-400 focus:ring-cyber-purple-400 focus:ring-offset-gray-900"
                 />
                 <div className="flex-1">
@@ -199,34 +194,37 @@ export function PDFExtractionSaveOptions({
               </label>
             </div>
 
-            {/* Folder Name (if ZIP) */}
-            {saveToZip && (
-              <div>
-                <label className="block text-sm font-semibold text-gray-400 mb-3">
-                  Folder Name {saveToZip && <span className="text-red-400">*</span>}
-                </label>
-                <input
-                  type="text"
-                  value={folderName}
-                  onChange={(e) => {
-                    setFolderName(e.target.value);
-                    if (folderNameError) {
-                      setFolderNameError(null);
-                    }
-                  }}
-                  placeholder="Enter folder name..."
-                  aria-required="true"
-                  className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
-                    folderNameError
-                      ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
-                      : 'border-gray-700 focus:ring-cyber-purple-400'
-                  }`}
-                />
-                {folderNameError && (
-                  <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
-                )}
-              </div>
-            )}
+            {/* Folder Name */}
+            <div>
+              <label className="block text-sm font-semibold text-gray-400 mb-3">
+                Folder Name <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="text"
+                value={folderName}
+                onChange={(e) => {
+                  setFolderName(e.target.value);
+                  if (folderNameError) {
+                    setFolderNameError(null);
+                  }
+                }}
+                placeholder="Enter folder name..."
+                aria-required="true"
+                className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                  folderNameError
+                    ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                    : 'border-gray-700 focus:ring-cyber-purple-400'
+                }`}
+              />
+              {folderNameError && (
+                <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
+              )}
+              <p className="text-xs text-gray-500 mt-2">
+                {saveToZip
+                  ? 'This name will be used for the ZIP file'
+                  : 'A subfolder with this name will be created to store the extracted images'}
+              </p>
+            </div>
 
             {/* File Naming Pattern */}
             <div>
@@ -267,7 +265,7 @@ export function PDFExtractionSaveOptions({
             </button>
             <button
               onClick={handleConfirm}
-              disabled={!saveDirectory || (saveToZip && !folderName.trim())}
+              disabled={!saveDirectory || !folderName.trim()}
               className="px-6 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-lg font-medium transition-all disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Save className="w-4 h-4" />

--- a/src/components/PDFExtractionSaveOptions.tsx
+++ b/src/components/PDFExtractionSaveOptions.tsx
@@ -36,6 +36,7 @@ export function PDFExtractionSaveOptions({
   const [saveToZip, setSaveToZip] = useState(false);
   const [fileNamingPattern, setFileNamingPattern] = useState('page-{n}');
   const [customPattern, setCustomPattern] = useState('');
+  const [folderNameError, setFolderNameError] = useState<string | null>(null);
 
   const handleSelectDirectory = async () => {
     try {
@@ -53,6 +54,12 @@ export function PDFExtractionSaveOptions({
 
   const handleConfirm = () => {
     if (!saveDirectory) {
+      return;
+    }
+
+    // Validate folder name when saveToZip is true
+    if (saveToZip && !folderName.trim()) {
+      setFolderNameError('Folder Name is required when saving to ZIP folder');
       return;
     }
 
@@ -172,7 +179,12 @@ export function PDFExtractionSaveOptions({
                 <input
                   type="checkbox"
                   checked={saveToZip}
-                  onChange={(e) => setSaveToZip(e.target.checked)}
+                  onChange={(e) => {
+                    setSaveToZip(e.target.checked);
+                    if (!e.target.checked && folderNameError) {
+                      setFolderNameError(null);
+                    }
+                  }}
                   className="w-5 h-5 rounded border-gray-600 text-cyber-purple-400 focus:ring-cyber-purple-400 focus:ring-offset-gray-900"
                 />
                 <div className="flex-1">
@@ -191,15 +203,28 @@ export function PDFExtractionSaveOptions({
             {saveToZip && (
               <div>
                 <label className="block text-sm font-semibold text-gray-400 mb-3">
-                  Folder Name
+                  Folder Name {saveToZip && <span className="text-red-400">*</span>}
                 </label>
                 <input
                   type="text"
                   value={folderName}
-                  onChange={(e) => setFolderName(e.target.value)}
+                  onChange={(e) => {
+                    setFolderName(e.target.value);
+                    if (folderNameError) {
+                      setFolderNameError(null);
+                    }
+                  }}
                   placeholder="Enter folder name..."
-                  className="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
+                  aria-required="true"
+                  className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                    folderNameError
+                      ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                      : 'border-gray-700 focus:ring-cyber-purple-400'
+                  }`}
                 />
+                {folderNameError && (
+                  <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
+                )}
               </div>
             )}
 
@@ -242,7 +267,7 @@ export function PDFExtractionSaveOptions({
             </button>
             <button
               onClick={handleConfirm}
-              disabled={!saveDirectory}
+              disabled={!saveDirectory || (saveToZip && !folderName.trim())}
               className="px-6 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-lg font-medium transition-all disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Save className="w-4 h-4" />

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -58,6 +58,7 @@ declare global {
         casePath: string;
         folderName: string;
         saveParentFile: boolean;
+        saveToZip: boolean;
         extractedPages: Array<{ pageNumber: number; imageData: string; fileName: string }>;
       }) => Promise<{ success: boolean; messages: string[]; extractionFolder: string }>;
       logToMain: (level: LogLevel, ...args: LogArgs) => Promise<void>;

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -180,6 +180,7 @@ declare global {
         progress: any | null;
         error: string | null;
         statusMessage: string;
+        caseFolderPath?: string | null;
       }) => Promise<{ success: boolean }>;
       reattachPdfExtraction: (options: {
         pdfPath: string | null;
@@ -199,6 +200,7 @@ declare global {
         progress: any | null;
         error: string | null;
         statusMessage: string;
+        caseFolderPath?: string | null;
       }) => Promise<{ success: boolean }>;
       closeWindow: () => Promise<{ success: boolean }>;
       openBookmarkInMainWindow: (options: {

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -58,7 +58,7 @@ declare global {
         casePath: string;
         folderName: string;
         saveParentFile: boolean;
-        extractedPages: Array<{ pageNumber: number; imageData: string }>;
+        extractedPages: Array<{ pageNumber: number; imageData: string; fileName: string }>;
       }) => Promise<{ success: boolean; messages: string[]; extractionFolder: string }>;
       logToMain: (level: LogLevel, ...args: LogArgs) => Promise<void>;
       debugLog: (logEntry: {

--- a/src/types/electronAPI.d.ts
+++ b/src/types/electronAPI.d.ts
@@ -17,7 +17,7 @@ declare global {
         saveToZip: boolean;
         folderName?: string;
         parentFilePath?: string;
-        extractedPages: Array<{ pageNumber: number; imageData: string }>;
+        extractedPages: Array<{ pageNumber: number; imageData: string; fileName: string }>;
       }) => Promise<{ success: boolean; messages: string[] }>;
       validatePath: (filePath: string) => Promise<{ isValid: boolean; isPDF: boolean }>;
       readPDFFile: (filePath: string) => Promise<{ type: 'base64'; data: string } | { type: 'file-path'; path: string } | string | number[]>;


### PR DESCRIPTION
This set of pull requests significantly improves the PDF extraction and saving workflow, addressing several bugs and adding new features for a more robust and user-friendly experience. The updates ensure that extracted images are always saved correctly (whether as individual files or in a ZIP), require folder names for all save operations, and improve handling of case folder paths and state during modal detach/reattach flows. Additionally, the extraction handlers now support custom file naming and proper archive folder positioning and refreshing.

The most important changes are:

**PDF Extraction and Saving Logic Improvements**
* The `save-files` handler in `electron/main.ts` now always requires a folder name and supports saving individual image files when `saveToZip` is false, creating a subfolder for loose files and using the provided `fileName` for each image. This fixes a bug where images weren't saved unless saving to ZIP. [[1]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[2]](diffhunk://#diff-ed559468ff3a3aa51aff731ebcd1ecfbc8415648c242fba3c0f46bd9b347833cR1-R64) [[3]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL551-R551) [[4]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL561-R596)
* The UI (`PDFExtractionSaveOptions.tsx`) now always shows and requires the folder name input for all save operations, improving validation and user clarity.

**ZIP Archive and Custom File Naming Support**
* The `extractPDFFromArchive` handler and related frontend logic now support a `saveToZip` option, allowing users to save extracted images as a ZIP archive directly from the archive modal.
* Both `save-files` and `extractPDFFromArchive` handlers now accept custom `fileName` values for each extracted page, enabling consistent file naming patterns from the frontend. [[1]](diffhunk://#diff-2d095b5412e649d401f34b4f739f645a6af8aaebc27ab5398022a2e9bfe55cafR1-R107) [[2]](diffhunk://#diff-c4bd988edbfd045455c27fd1984b3539e723b62341a7bccd13eb8a82faf1eaa5R1-R94)

**Case Folder Path and State Handling**
* The flow for detaching and reattaching the PDF extraction modal now preserves the `caseFolderPath`, ensuring that saves from a detached window are correctly linked to the archive case folder. This involves changes to both frontend and backend handlers and state management. [[1]](diffhunk://#diff-5b96015a1cb48b8da0eb851a060f68fd9aae0df0e9c191320ba253db3429348dR1-R46) [[2]](diffhunk://#diff-aacec714120861cf8923f3e5077cad60f4b0a94b6859fbc3508887fbb1eab061R1-R53)
* Improved state restoration logic ensures that extracted pages and case folder path are not lost when reattaching the modal, fixing a race condition and missing prop handling.

**Archive Folder Refresh and Positioning**
* The extraction workflow now always uses `extractPDFFromArchive` when saving to an archive case folder (for both ZIP and individual files), ensuring that the new folder appears in the case file list and is properly positioned above the parent PDF. The UI also triggers a refresh after save to immediately show the new files.

These changes collectively enhance reliability, user experience, and maintainability of the PDF extraction and saving features.