### PR TITLE
feat(pdf,word-editor): enhance save options and fix reattach content …

### DIFF
--- a/electron/utils/generateAuditReport.ts
+++ b/electron/utils/generateAuditReport.ts
@@ -98,8 +98,27 @@ export async function generateAuditReport(
     throw new Error(`Report generator script not found at: ${scriptPath}. Please reinstall the application.`);
   }
 
-  // Create temporary JSON file with audit data
-  const tempJsonPath = path.join(path.dirname(outputPath), `audit_temp_${Date.now()}.json`);
+  // Normalize the output path first (handles forward/backward slashes correctly)
+  const normalizedOutputPath = path.normalize(outputPath);
+  
+  // Ensure output directory exists (create all parent directories recursively)
+  const outputDir = path.dirname(normalizedOutputPath);
+  try {
+    // Use recursive: true to create all parent directories if they don't exist
+    await fs.mkdir(outputDir, { recursive: true });
+    // Verify the directory was created
+    const stats = await fs.stat(outputDir);
+    if (!stats.isDirectory()) {
+      throw new Error(`Path exists but is not a directory: ${outputDir}`);
+    }
+    logger.log('Output directory created/verified:', outputDir);
+  } catch (error) {
+    logger.error('Failed to create output directory:', { outputDir, normalizedOutputPath, error });
+    throw new Error(`Failed to create output directory: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+
+  // Create temporary JSON file with audit data (in the same directory as output)
+  const tempJsonPath = path.join(outputDir, `audit_temp_${Date.now()}.json`);
   
   try {
     // Write audit result to temp JSON file
@@ -108,7 +127,7 @@ export async function generateAuditReport(
     // Normalize all paths before passing to Python
     const normalizedScriptPath = path.normalize(scriptPath);
     const normalizedTempJsonPath = path.normalize(tempJsonPath);
-    const normalizedOutputPath = path.normalize(outputPath);
+    // Use the already normalized output path
 
     return new Promise((resolve, reject) => {
       // Build arguments array with normalized paths

--- a/src/components/Archive/ArchivePage.tsx
+++ b/src/components/Archive/ArchivePage.tsx
@@ -16,6 +16,7 @@ import { ExtractionFolderDialog } from './ExtractionFolderDialog';
 import { SaveParentDialog } from './SaveParentDialog';
 import { FolderSelectionDialog } from './FolderSelectionDialog';
 import { DeleteFolderConfirmDialog } from './DeleteFolderConfirmDialog';
+import { DeletePDFConfirmDialog } from './DeletePDFConfirmDialog';
 import { RenameFileDialog } from './RenameFileDialog';
 import { CreateFolderDialog } from './CreateFolderDialog';
 import { ExtractionFolder } from './ExtractionFolder';
@@ -193,6 +194,8 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
   const [showSaveParentDialog, setShowSaveParentDialog] = useState(false);
   const [showDeleteFolderDialog, setShowDeleteFolderDialog] = useState(false);
   const [folderToDelete, setFolderToDelete] = useState<ArchiveFile | null>(null);
+  const [showDeletePDFDialog, setShowDeletePDFDialog] = useState(false);
+  const [pdfToDelete, setPdfToDelete] = useState<ArchiveFile | null>(null);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [fileToRename, setFileToRename] = useState<ArchiveFile | null>(null);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
@@ -1531,13 +1534,20 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                                     file={item}
                                     onClick={() => handleFileClick(item)}
                                     onDelete={async () => {
-                                      // Close file viewer if this file is currently open
-                                      if (selectedFile?.path === item.path) {
-                                        setSelectedFile(null);
-                                        // Small delay to ensure viewer closes and releases file handle
-                                        await new Promise(resolve => setTimeout(resolve, 100));
+                                      if (item.type === 'pdf') {
+                                        // Show confirmation dialog for PDFs
+                                        setPdfToDelete(item);
+                                        setShowDeletePDFDialog(true);
+                                      } else {
+                                        // Direct deletion for non-PDF files
+                                        // Close file viewer if this file is currently open
+                                        if (selectedFile?.path === item.path) {
+                                          setSelectedFile(null);
+                                          // Small delay to ensure viewer closes and releases file handle
+                                          await new Promise(resolve => setTimeout(resolve, 100));
+                                        }
+                                        await deleteFile(item.path);
                                       }
-                                      await deleteFile(item.path);
                                     }}
                                     onExtract={item.type === 'pdf' ? () => handleExtractPDF(item) : undefined}
                                     onRunAudit={item.type === 'pdf' ? () => handleRunPDFAudit(item) : undefined}
@@ -1682,13 +1692,20 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                                 file={item}
                                 onClick={() => handleFileClick(item)}
                                 onDelete={async () => {
-                                  // Close file viewer if this file is currently open
-                                  if (selectedFile?.path === item.path) {
-                                    setSelectedFile(null);
-                                    // Small delay to ensure viewer closes and releases file handle
-                                    await new Promise(resolve => setTimeout(resolve, 100));
+                                  if (item.type === 'pdf') {
+                                    // Show confirmation dialog for PDFs
+                                    setPdfToDelete(item);
+                                    setShowDeletePDFDialog(true);
+                                  } else {
+                                    // Direct deletion for non-PDF files
+                                    // Close file viewer if this file is currently open
+                                    if (selectedFile?.path === item.path) {
+                                      setSelectedFile(null);
+                                      // Small delay to ensure viewer closes and releases file handle
+                                      await new Promise(resolve => setTimeout(resolve, 100));
+                                    }
+                                    await deleteFile(item.path);
                                   }
-                                  await deleteFile(item.path);
                                 }}
                                 onExtract={() => handleExtractPDF(item)}
                                 onRunAudit={item.type === 'pdf' ? () => handleRunPDFAudit(item) : undefined}
@@ -1907,6 +1924,62 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
         }}
       />
 
+      <DeletePDFConfirmDialog
+        isOpen={showDeletePDFDialog}
+        fileName={pdfToDelete?.name || ''}
+        hasExistingFolder={pdfToDelete ? files.some(
+          (file) =>
+            file.isFolder &&
+            file.parentPdfName &&
+            pdfToDelete.name &&
+            file.parentPdfName.toLowerCase() === pdfToDelete.name.toLowerCase()
+        ) : false}
+        onClose={() => {
+          setShowDeletePDFDialog(false);
+          setPdfToDelete(null);
+        }}
+        onConfirm={async (deleteImageFolder: boolean) => {
+          if (pdfToDelete) {
+            // Close file viewer if this PDF is currently open
+            if (selectedFile?.path === pdfToDelete.path) {
+              setSelectedFile(null);
+              // Small delay to ensure viewer closes and releases file handle
+              await new Promise(resolve => setTimeout(resolve, 100));
+            }
+
+            // Find and delete associated extraction folders if checkbox is checked
+            if (deleteImageFolder) {
+              const pdfName = pdfToDelete.name;
+              const associatedFolders = files.filter(
+                (file) =>
+                  file.isFolder &&
+                  file.parentPdfName &&
+                  file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+              );
+
+              // Delete all associated extraction folders
+              for (const folder of associatedFolders) {
+                try {
+                  // Close file viewer if we're deleting a folder we're currently viewing
+                  if (selectedFile && selectedFile.path.startsWith(folder.path)) {
+                    setSelectedFile(null);
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                  }
+                  await deleteFile(folder.path, true);
+                } catch (error) {
+                  logger.error(`Failed to delete extraction folder ${folder.path}:`, error);
+                  // Continue with PDF deletion even if folder deletion fails
+                }
+              }
+            }
+
+            // Delete the PDF file
+            await deleteFile(pdfToDelete.path);
+            setPdfToDelete(null);
+          }
+        }}
+      />
+
       <RenameFileDialog
         isOpen={showRenameDialog}
         currentName={fileToRename?.name || ''}
@@ -1980,6 +2053,13 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
         initialPdfPath={pdfPathForAudit}
         caseFolderPath={currentCase?.path || null}
         onReportSaved={handleReportSaved}
+        existingFolders={pdfPathForAudit ? files.filter(
+          (file) =>
+            file.isFolder &&
+            file.parentPdfName &&
+            pdfPathForAudit &&
+            file.parentPdfName.toLowerCase() === pdfPathForAudit.split(/[/\\]/).pop()?.toLowerCase()
+        ) : undefined}
       />
 
       <PDFExtractionModal
@@ -1995,6 +2075,13 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
             refreshFiles();
           }
         }}
+        existingFolders={pdfPathForExtraction ? files.filter(
+          (file) =>
+            file.isFolder &&
+            file.parentPdfName &&
+            pdfPathForExtraction &&
+            file.parentPdfName.toLowerCase() === pdfPathForExtraction.split(/[/\\]/).pop()?.toLowerCase()
+        ) : undefined}
       />
     </div>
   );

--- a/src/components/Archive/DeletePDFConfirmDialog.tsx
+++ b/src/components/Archive/DeletePDFConfirmDialog.tsx
@@ -1,0 +1,134 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { useState } from 'react';
+import { Trash2, AlertTriangle } from 'lucide-react';
+
+interface DeletePDFConfirmDialogProps {
+  isOpen: boolean;
+  fileName: string;
+  onClose: () => void;
+  onConfirm: (deleteImageFolder: boolean) => void;
+  hasExistingFolder?: boolean; // Whether there's an existing PDF folder to delete
+}
+
+export function DeletePDFConfirmDialog({ 
+  isOpen, 
+  fileName, 
+  onClose, 
+  onConfirm,
+  hasExistingFolder = false
+}: DeletePDFConfirmDialogProps) {
+  const [deleteImageFolder, setDeleteImageFolder] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleConfirm = () => {
+    onConfirm(deleteImageFolder);
+    onClose();
+    // Reset checkbox state after closing
+    setDeleteImageFolder(false);
+  };
+
+  const handleClose = () => {
+    onClose();
+    // Reset checkbox state when closing
+    setDeleteImageFolder(false);
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={handleClose}
+        className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-pdf-dialog-title"
+        aria-describedby="delete-pdf-dialog-description"
+      >
+        <motion.div
+          initial={{ scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.9, opacity: 0 }}
+          onClick={(e) => e.stopPropagation()}
+          className="bg-gradient-to-br from-gray-800 to-gray-900 rounded-lg border-2 border-red-500/60 shadow-2xl p-6 max-w-md w-full"
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 bg-red-600/20 rounded-lg border border-red-500/50" aria-hidden="true">
+              <AlertTriangle className="w-6 h-6 text-red-400" />
+            </div>
+            <h2 id="delete-pdf-dialog-title" className="text-2xl font-bold text-red-400">
+              Delete PDF?
+            </h2>
+          </div>
+
+          <div id="delete-pdf-dialog-description">
+            <p className="text-gray-300 mb-2">
+              Are you sure you want to delete <span className="font-semibold text-white">"{fileName}"</span>?
+            </p>
+            
+            <p className="text-red-400 text-sm mb-4">
+              ⚠️ This action cannot be undone.
+            </p>
+
+            {/* Checkbox for deleting PDF folder - only show if folder exists */}
+            {hasExistingFolder && (
+              <div className="mb-6">
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <div className="relative">
+                    <input
+                      type="checkbox"
+                      checked={deleteImageFolder}
+                      onChange={(e) => setDeleteImageFolder(e.target.checked)}
+                      className="sr-only"
+                      aria-label="Delete PDF Folder"
+                    />
+                    <div
+                      className={`w-5 h-5 rounded-full border-2 transition-all ${
+                        deleteImageFolder
+                          ? 'bg-red-600 border-red-500'
+                          : 'bg-transparent border-gray-500 group-hover:border-red-400'
+                      }`}
+                    >
+                      {deleteImageFolder && (
+                        <motion.div
+                          initial={{ scale: 0 }}
+                          animate={{ scale: 1 }}
+                          className="w-full h-full flex items-center justify-center"
+                        >
+                          <div className="w-2 h-2 rounded-full bg-white" />
+                        </motion.div>
+                      )}
+                    </div>
+                  </div>
+                  <span className="text-gray-300 group-hover:text-white transition-colors">
+                    Delete PDF Folder
+                  </span>
+                </label>
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              onClick={handleClose}
+              className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+              aria-label="Cancel deleting PDF"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              className="flex-1 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors font-semibold flex items-center justify-center gap-2"
+              aria-label={`Confirm deletion of PDF ${fileName}`}
+            >
+              <Trash2 className="w-4 h-4" aria-hidden="true" />
+              Delete PDF
+            </button>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/AuditSaveOptionsDialog.tsx
+++ b/src/components/AuditSaveOptionsDialog.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { X, FolderOpen, Save, FileText, FolderPlus } from 'lucide-react';
 import { ArchiveFile } from '../types';
 
@@ -61,6 +61,7 @@ export function AuditSaveOptionsDialog({
   const [createNewFolderForLoose, setCreateNewFolderForLoose] = useState(false);
   const [looseFolderName, setLooseFolderName] = useState('');
   const [folderNameError, setFolderNameError] = useState<string | null>(null);
+  const hasInitializedFolderName = useRef(false);
 
   // Detect existing folders on mount or when props change
   useEffect(() => {
@@ -88,13 +89,20 @@ export function AuditSaveOptionsDialog({
     }
   }, [isOpen, pdfPath, casePath, existingFolders]);
 
-  // Generate default folder name from PDF name
+  // Generate default folder name from PDF name - only when dialog opens or pdfPath changes
   useEffect(() => {
-    if (pdfPath && !folderName) {
+    if (isOpen && pdfPath && !hasInitializedFolderName.current) {
       const pdfName = pdfPath.split(/[/\\]/).pop()?.replace(/\.pdf$/i, '') || 'audit_report';
       setFolderName(pdfName);
+      hasInitializedFolderName.current = true;
     }
-  }, [pdfPath, folderName]);
+    
+    // Reset initialization flag when dialog closes
+    if (!isOpen) {
+      hasInitializedFolderName.current = false;
+      setFolderName('');
+    }
+  }, [isOpen, pdfPath]);
 
   const hasExistingFolder = detectedFolders.length > 0;
   const firstExistingFolder = detectedFolders[0];
@@ -313,6 +321,7 @@ export function AuditSaveOptionsDialog({
                               setFolderNameError(null);
                             }
                           }}
+                          onFocus={(e) => e.target.select()}
                           placeholder="Enter folder name..."
                           className={`w-full px-3 py-2 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
                             folderNameError
@@ -380,6 +389,7 @@ export function AuditSaveOptionsDialog({
                           type="text"
                           value={folderName}
                           onChange={(e) => setFolderName(e.target.value)}
+                          onFocus={(e) => e.target.select()}
                           placeholder="Enter folder name..."
                           className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
                         />

--- a/src/components/AuditSaveOptionsDialog.tsx
+++ b/src/components/AuditSaveOptionsDialog.tsx
@@ -1,0 +1,526 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useEffect } from 'react';
+import { X, FolderOpen, Save, FileText, FolderPlus } from 'lucide-react';
+import { ArchiveFile } from '../types';
+
+export type AuditSaveOption = 'save-loose' | 'make-pdf-folder' | 'add-to-pdf-folder' | 'add-folder-to-directory';
+
+interface AuditSaveOptionsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (option: AuditSaveOption, folderName?: string, subfolderName?: string, createNewFolderForLoose?: boolean, looseFolderName?: string) => void;
+  pdfPath: string | null;
+  casePath: string | null;
+  existingFolders?: ArchiveFile[]; // Optional: if called from ArchivePage context
+}
+
+// Helper function to find extraction folders for a PDF
+async function findExtractionFoldersForPDF(
+  pdfPath: string | null,
+  casePath: string | null
+): Promise<ArchiveFile[]> {
+  if (!pdfPath || !casePath || !window.electronAPI) {
+    return [];
+  }
+
+  try {
+    // Get PDF filename for matching
+    const pdfName = pdfPath.split(/[/\\]/).pop() || '';
+    
+    // List case files to find folders
+    const files = await window.electronAPI.listCaseFiles(casePath);
+    
+    // Filter for folders with matching parentPdfName
+    // Note: listCaseFiles returns a simplified type, so we need to cast/check properties
+    return files.filter(
+      (file: any) =>
+        file.isFolder &&
+        file.parentPdfName &&
+        file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+    ) as ArchiveFile[];
+  } catch (error) {
+    console.error('Failed to find extraction folders:', error);
+    return [];
+  }
+}
+
+export function AuditSaveOptionsDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  pdfPath,
+  casePath,
+  existingFolders,
+}: AuditSaveOptionsDialogProps) {
+  const [selectedOption, setSelectedOption] = useState<AuditSaveOption | null>(null);
+  const [detectedFolders, setDetectedFolders] = useState<ArchiveFile[]>([]);
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [subfolderName, setSubfolderName] = useState('');
+  const [showSubfolderInput, setShowSubfolderInput] = useState(false);
+  const [folderName, setFolderName] = useState('');
+  const [createNewFolderForLoose, setCreateNewFolderForLoose] = useState(false);
+  const [looseFolderName, setLooseFolderName] = useState('');
+  const [folderNameError, setFolderNameError] = useState<string | null>(null);
+
+  // Detect existing folders on mount or when props change
+  useEffect(() => {
+    if (isOpen && pdfPath && casePath) {
+      setIsDetecting(true);
+      
+      // Use provided folders if available, otherwise detect
+      if (existingFolders && existingFolders.length > 0) {
+        setDetectedFolders(existingFolders);
+        setIsDetecting(false);
+      } else {
+        findExtractionFoldersForPDF(pdfPath, casePath)
+          .then((folders) => {
+            setDetectedFolders(folders);
+            setIsDetecting(false);
+          })
+          .catch((error) => {
+            console.error('Error detecting folders:', error);
+            setDetectedFolders([]);
+            setIsDetecting(false);
+          });
+      }
+    } else {
+      setDetectedFolders([]);
+    }
+  }, [isOpen, pdfPath, casePath, existingFolders]);
+
+  // Generate default folder name from PDF name
+  useEffect(() => {
+    if (pdfPath && !folderName) {
+      const pdfName = pdfPath.split(/[/\\]/).pop()?.replace(/\.pdf$/i, '') || 'audit_report';
+      setFolderName(pdfName);
+    }
+  }, [pdfPath, folderName]);
+
+  const hasExistingFolder = detectedFolders.length > 0;
+  const firstExistingFolder = detectedFolders[0];
+
+  const handleOptionSelect = (option: AuditSaveOption) => {
+    setSelectedOption(option);
+    
+    if (option === 'add-folder-to-directory') {
+      setShowSubfolderInput(true);
+      setCreateNewFolderForLoose(false);
+    } else if (option === 'save-loose') {
+      setShowSubfolderInput(false);
+      // Don't reset createNewFolderForLoose - let user toggle it
+    } else {
+      setShowSubfolderInput(false);
+      setCreateNewFolderForLoose(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!selectedOption) return;
+
+    if (selectedOption === 'add-folder-to-directory' && !subfolderName.trim()) {
+      return; // Don't allow empty subfolder name
+    }
+
+    if (selectedOption === 'make-pdf-folder' && !folderName.trim()) {
+      return; // Don't allow empty folder name
+    }
+
+    if (selectedOption === 'save-loose' && createNewFolderForLoose && !looseFolderName.trim()) {
+      setFolderNameError('Folder name is required');
+      return;
+    }
+
+    onConfirm(
+      selectedOption,
+      selectedOption === 'make-pdf-folder' 
+        ? folderName.trim() 
+        : (selectedOption === 'save-loose' && createNewFolderForLoose ? looseFolderName.trim() : undefined),
+      selectedOption === 'add-folder-to-directory' ? subfolderName.trim() : undefined,
+      selectedOption === 'save-loose' ? createNewFolderForLoose : false,
+      selectedOption === 'save-loose' && createNewFolderForLoose ? looseFolderName.trim() : undefined
+    );
+    
+    // Reset state
+    setSelectedOption(null);
+    setSubfolderName('');
+    setShowSubfolderInput(false);
+    setCreateNewFolderForLoose(false);
+    setLooseFolderName('');
+    setFolderNameError(null);
+    onClose();
+  };
+
+  const handleClose = () => {
+    setSelectedOption(null);
+    setSubfolderName('');
+    setShowSubfolderInput(false);
+    setCreateNewFolderForLoose(false);
+    setLooseFolderName('');
+    setFolderNameError(null);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={handleClose}
+        className="fixed inset-0 z-[60] bg-black/80 backdrop-blur-sm flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="audit-save-dialog-title"
+      >
+        <motion.div
+          initial={{ scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.9, opacity: 0 }}
+          onClick={(e) => e.stopPropagation()}
+          className="bg-gradient-to-br from-gray-900 via-purple-900/20 to-gray-900 rounded-2xl border-2 border-cyber-purple-400/40 shadow-2xl max-w-lg w-full max-h-[90vh] overflow-hidden flex flex-col"
+        >
+          {/* Header */}
+          <div className="relative p-6 border-b border-cyber-purple-400/30 bg-gradient-to-r from-gray-900/95 via-purple-900/20 to-gray-900/95 backdrop-blur-xl">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="relative">
+                  <div className="absolute inset-0 bg-gradient-to-br from-purple-600 to-cyan-600 rounded-xl blur-xl opacity-50"></div>
+                  <div className="relative p-3 bg-gradient-to-br from-purple-600 to-cyan-600 rounded-xl shadow-2xl">
+                    <Save className="w-6 h-6 text-white" />
+                  </div>
+                </div>
+                <div>
+                  <h2 id="audit-save-dialog-title" className="text-2xl font-bold bg-gradient-to-r from-cyber-purple-400 via-cyber-cyan-400 to-cyber-purple-400 bg-clip-text text-transparent">
+                    Save Audit Report
+                  </h2>
+                  <p className="text-sm text-gray-400 mt-1">
+                    Choose where to save the audit report
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={handleClose}
+                className="p-2 hover:bg-gray-800 rounded-xl transition-colors"
+                aria-label="Close"
+              >
+                <X className="w-5 h-5 text-gray-400" />
+              </button>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto p-6 space-y-4">
+            {isDetecting ? (
+              <div className="flex items-center justify-center py-8">
+                <div className="text-gray-400">Detecting existing folders...</div>
+              </div>
+            ) : (
+              <>
+                {/* Save Loose Option */}
+                <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                  <div className="relative">
+                    <input
+                      type="radio"
+                      name="save-option"
+                      value="save-loose"
+                      checked={selectedOption === 'save-loose'}
+                      onChange={() => handleOptionSelect('save-loose')}
+                      className="sr-only"
+                    />
+                    <div
+                      className={`w-5 h-5 rounded-full border-2 transition-all ${
+                        selectedOption === 'save-loose'
+                          ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                          : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                      }`}
+                    >
+                      {selectedOption === 'save-loose' && (
+                        <motion.div
+                          initial={{ scale: 0 }}
+                          animate={{ scale: 1 }}
+                          className="w-full h-full flex items-center justify-center"
+                        >
+                          <div className="w-2 h-2 rounded-full bg-white" />
+                        </motion.div>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <FileText className="w-4 h-4 text-gray-400" />
+                      <span className="text-sm font-medium text-gray-200">Save Loose</span>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Save to case folder (uses default folder name if no custom folder is created)
+                    </p>
+                  </div>
+                </label>
+
+                {/* Create New Folder option - expands when Save Loose is selected */}
+                {selectedOption === 'save-loose' && (
+                  <div className="ml-8 pl-4 border-l-2 border-cyber-purple-400/30 space-y-3">
+                    <label className="flex items-center gap-3 p-3 bg-gray-800/30 rounded-lg border border-gray-700/30 cursor-pointer hover:bg-gray-800/50 transition-colors group">
+                      <div className="relative">
+                        <input
+                          type="checkbox"
+                          checked={createNewFolderForLoose}
+                          onChange={(e) => {
+                            setCreateNewFolderForLoose(e.target.checked);
+                            if (!e.target.checked) {
+                              setLooseFolderName('');
+                              setFolderNameError(null);
+                            }
+                          }}
+                          className="sr-only"
+                        />
+                        <div
+                          className={`w-4 h-4 rounded border-2 transition-all ${
+                            createNewFolderForLoose
+                              ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                              : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                          }`}
+                        >
+                          {createNewFolderForLoose && (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              className="w-full h-full flex items-center justify-center"
+                            >
+                              <div className="w-1.5 h-1.5 rounded-full bg-white" />
+                            </motion.div>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <span className="text-sm font-medium text-gray-300">Create New Folder inside case file</span>
+                      </div>
+                    </label>
+
+                    {/* Folder Name Input (shown when Create New Folder is checked) */}
+                    {createNewFolderForLoose && (
+                      <div>
+                        <label className="block text-xs font-semibold text-gray-400 mb-2">
+                          Folder Name
+                        </label>
+                        <input
+                          type="text"
+                          value={looseFolderName}
+                          onChange={(e) => {
+                            setLooseFolderName(e.target.value);
+                            if (folderNameError) {
+                              setFolderNameError(null);
+                            }
+                          }}
+                          placeholder="Enter folder name..."
+                          className={`w-full px-3 py-2 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                            folderNameError
+                              ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                              : 'border-gray-700 focus:ring-cyber-purple-400'
+                          }`}
+                        />
+                        {folderNameError && (
+                          <p className="text-red-400 text-xs mt-2">{folderNameError}</p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Make PDF Folder Option - Only show if no existing folder */}
+                {!hasExistingFolder && (
+                  <>
+                    <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                      <div className="relative">
+                        <input
+                          type="radio"
+                          name="save-option"
+                          value="make-pdf-folder"
+                          checked={selectedOption === 'make-pdf-folder'}
+                          onChange={() => handleOptionSelect('make-pdf-folder')}
+                          className="sr-only"
+                        />
+                        <div
+                          className={`w-5 h-5 rounded-full border-2 transition-all ${
+                            selectedOption === 'make-pdf-folder'
+                              ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                              : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                          }`}
+                        >
+                          {selectedOption === 'make-pdf-folder' && (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              className="w-full h-full flex items-center justify-center"
+                            >
+                              <div className="w-2 h-2 rounded-full bg-white" />
+                            </motion.div>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <FolderPlus className="w-4 h-4 text-gray-400" />
+                          <span className="text-sm font-medium text-gray-200">Make PDF Folder</span>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                          Create folder above PDF (like Convert to Images)
+                        </p>
+                      </div>
+                    </label>
+
+                    {/* Folder Name Input (shown when Make PDF Folder is selected) */}
+                    {selectedOption === 'make-pdf-folder' && (
+                      <div className="ml-8 pl-4 border-l-2 border-cyber-purple-400/30">
+                        <label className="block text-xs font-semibold text-gray-400 mb-2">
+                          Folder Name
+                        </label>
+                        <input
+                          type="text"
+                          value={folderName}
+                          onChange={(e) => setFolderName(e.target.value)}
+                          placeholder="Enter folder name..."
+                          className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {/* Additional options when folder exists */}
+                {hasExistingFolder && (
+                  <>
+                    {/* Add to PDF Folder Option */}
+                    <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                      <div className="relative">
+                        <input
+                          type="radio"
+                          name="save-option"
+                          value="add-to-pdf-folder"
+                          checked={selectedOption === 'add-to-pdf-folder'}
+                          onChange={() => handleOptionSelect('add-to-pdf-folder')}
+                          className="sr-only"
+                        />
+                        <div
+                          className={`w-5 h-5 rounded-full border-2 transition-all ${
+                            selectedOption === 'add-to-pdf-folder'
+                              ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                              : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                          }`}
+                        >
+                          {selectedOption === 'add-to-pdf-folder' && (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              className="w-full h-full flex items-center justify-center"
+                            >
+                              <div className="w-2 h-2 rounded-full bg-white" />
+                            </motion.div>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <FolderOpen className="w-4 h-4 text-gray-400" />
+                          <span className="text-sm font-medium text-gray-200">
+                            Add to PDF Folder
+                          </span>
+                          <span className="text-xs text-gray-500">({firstExistingFolder.name})</span>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                          Save to existing folder: {firstExistingFolder.name}
+                        </p>
+                      </div>
+                    </label>
+
+                    {/* Add Folder to Directory Option */}
+                    <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                      <div className="relative">
+                        <input
+                          type="radio"
+                          name="save-option"
+                          value="add-folder-to-directory"
+                          checked={selectedOption === 'add-folder-to-directory'}
+                          onChange={() => handleOptionSelect('add-folder-to-directory')}
+                          className="sr-only"
+                        />
+                        <div
+                          className={`w-5 h-5 rounded-full border-2 transition-all ${
+                            selectedOption === 'add-folder-to-directory'
+                              ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                              : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                          }`}
+                        >
+                          {selectedOption === 'add-folder-to-directory' && (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              className="w-full h-full flex items-center justify-center"
+                            >
+                              <div className="w-2 h-2 rounded-full bg-white" />
+                            </motion.div>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <FolderPlus className="w-4 h-4 text-gray-400" />
+                          <span className="text-sm font-medium text-gray-200">
+                            Make Subfolder Within PDF Folder
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                          Create subfolder inside {firstExistingFolder.name}
+                        </p>
+                      </div>
+                    </label>
+
+                    {/* Subfolder Name Input (shown when Add Folder to Directory is selected) */}
+                    {showSubfolderInput && (
+                      <div className="ml-8 pl-4 border-l-2 border-cyber-purple-400/30">
+                        <label className="block text-xs font-semibold text-gray-400 mb-2">
+                          Subfolder Name
+                        </label>
+                        <input
+                          type="text"
+                          value={subfolderName}
+                          onChange={(e) => setSubfolderName(e.target.value)}
+                          placeholder="Enter subfolder name (e.g., Audit Reports)..."
+                          className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="p-6 border-t border-cyber-purple-400/30 bg-gray-900/50 flex items-center justify-end gap-3">
+            <button
+              onClick={handleClose}
+              className="px-6 py-2.5 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={
+                !selectedOption ||
+                (selectedOption === 'add-folder-to-directory' && !subfolderName.trim()) ||
+                (selectedOption === 'make-pdf-folder' && !folderName.trim()) ||
+                (selectedOption === 'save-loose' && createNewFolderForLoose && !looseFolderName.trim())
+              }
+              className="px-6 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-lg font-medium transition-all disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              <Save className="w-4 h-4" />
+              Save
+            </button>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/DetachedPDFExtraction.tsx
+++ b/src/components/DetachedPDFExtraction.tsx
@@ -235,8 +235,11 @@ export function DetachedPDFExtraction() {
   };
 
   const handleSave = async (saveOptions: {
+    saveOption: 'save-loose' | 'make-pdf-folder' | 'add-to-pdf-folder' | 'add-folder-to-directory';
     saveDirectory: string;
-    folderName: string;
+    folderName?: string;
+    subfolderName?: string;
+    createNewFolderForLoose?: boolean;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -267,12 +270,27 @@ export function DetachedPDFExtraction() {
         fileName: `${generateFileName(page.pageNumber, saveOptions.fileNamingPattern)}.${settings.format}`,
       }));
 
+      // Determine folder name based on save option
+      let targetFolderName: string;
+      if (saveOptions.saveOption === 'save-loose') {
+        // For save-loose, use provided folder name or default
+        targetFolderName = (saveOptions.createNewFolderForLoose && saveOptions.folderName) 
+          ? saveOptions.folderName 
+          : 'extracted_images';
+      } else {
+        // For other options, require folder name
+        if (!saveOptions.folderName) {
+          throw new Error('Folder name is required');
+        }
+        targetFolderName = saveOptions.folderName;
+      }
+
       if (caseFolderPath) {
         // Save to archive case folder (always use extractPDFFromArchive for archive)
         await window.electronAPI.extractPDFFromArchive({
           pdfPath: pdfPath!,
           casePath: caseFolderPath,
-          folderName: saveOptions.folderName,
+          folderName: targetFolderName,
           saveParentFile: saveOptions.saveParentFile,
           saveToZip: saveOptions.saveToZip,
           extractedPages: pagesWithNames.map((p) => ({
@@ -284,35 +302,19 @@ export function DetachedPDFExtraction() {
         toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''} to archive`);
       } else {
         // Save to regular directory
-        if (saveOptions.saveToZip) {
-          await window.electronAPI.saveFiles({
-            saveDirectory: saveOptions.saveDirectory,
-            saveParentFile: saveOptions.saveParentFile,
-            saveToZip: true,
-            folderName: saveOptions.folderName,
-            parentFilePath: pdfPath!,
-            extractedPages: pagesWithNames.map((p) => ({
-              pageNumber: p.pageNumber,
-              imageData: p.imageData,
-              fileName: p.fileName,
-            })),
-          });
-          toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
-        } else {
-          await window.electronAPI.saveFiles({
-            saveDirectory: saveOptions.saveDirectory,
-            saveParentFile: saveOptions.saveParentFile,
-            saveToZip: false,
-            folderName: saveOptions.folderName,
-            parentFilePath: pdfPath!,
-            extractedPages: pagesWithNames.map((p) => ({
-              pageNumber: p.pageNumber,
-              imageData: p.imageData,
-              fileName: p.fileName,
-            })),
-          });
-          toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
-        }
+        await window.electronAPI.saveFiles({
+          saveDirectory: saveOptions.saveDirectory,
+          saveParentFile: saveOptions.saveParentFile,
+          saveToZip: saveOptions.saveToZip,
+          folderName: targetFolderName,
+          parentFilePath: pdfPath!,
+          extractedPages: pagesWithNames.map((p) => ({
+            pageNumber: p.pageNumber,
+            imageData: p.imageData,
+            fileName: p.fileName,
+          })),
+        });
+        toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''}`);
       }
 
       setShowSaveDialog(false);

--- a/src/components/PDFExtractionModal.tsx
+++ b/src/components/PDFExtractionModal.tsx
@@ -18,12 +18,15 @@ import { PDFExtractionResults } from './PDFExtractionResults';
 import { PDFExtractionSaveOptions } from './PDFExtractionSaveOptions';
 import { ConversionSettings, ExtractedPage } from '../types';
 
+import { ArchiveFile } from '../types';
+
 interface PDFExtractionModalProps {
   isOpen: boolean;
   onClose: () => void;
   initialPdfPath?: string | null;
   caseFolderPath?: string | null;
   onExtractionComplete?: () => void;
+  existingFolders?: ArchiveFile[];
 }
 
 const DEFAULT_SETTINGS: ConversionSettings = {
@@ -41,6 +44,7 @@ export function PDFExtractionModal({
   initialPdfPath,
   caseFolderPath,
   onExtractionComplete,
+  existingFolders,
 }: PDFExtractionModalProps) {
   const [pdfPath, setPdfPath] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -333,8 +337,11 @@ export function PDFExtractionModal({
   };
 
   const handleSave = async (saveOptions: {
+    saveOption: 'save-loose' | 'make-pdf-folder' | 'add-to-pdf-folder' | 'add-folder-to-directory';
     saveDirectory: string;
-    folderName: string;
+    folderName?: string;
+    subfolderName?: string;
+    createNewFolderForLoose?: boolean;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
@@ -367,19 +374,160 @@ export function PDFExtractionModal({
       }));
 
       if (caseFolderPath) {
-        // Save to archive case folder (always use extractPDFFromArchive for archive)
-        await window.electronAPI.extractPDFFromArchive({
-          pdfPath: pdfPath!,
-          casePath: caseFolderPath,
-          folderName: saveOptions.folderName,
-          saveParentFile: saveOptions.saveParentFile,
-          saveToZip: saveOptions.saveToZip,
-          extractedPages: pagesWithNames.map((p) => ({
-            pageNumber: p.pageNumber,
-            imageData: p.imageData,
-            fileName: p.fileName,
-          })),
-        });
+        // Handle different save options for archive case folder
+        let targetFolderName: string = '';
+        let subfolderPath: string | null = null;
+
+        switch (saveOptions.saveOption) {
+          case 'save-loose': {
+            // For save-loose, we always need a folder name (saveFiles API requires it)
+            // If createNewFolderForLoose is true, use the provided folder name
+            // If false, use a default folder name (saveFiles will create it)
+            if (saveOptions.createNewFolderForLoose) {
+              if (!saveOptions.folderName || !saveOptions.folderName.trim()) {
+                throw new Error('Folder name is required');
+              }
+              targetFolderName = saveOptions.folderName.trim();
+            } else {
+              // Use a default folder name - saveFiles API requires it
+              // The folder will be created by saveFiles
+              targetFolderName = 'extracted_images';
+            }
+            break;
+          }
+
+          case 'make-pdf-folder': {
+            // Check if folder already exists
+            let existingFolderPath: string | null = null;
+            try {
+              const files = await window.electronAPI.listCaseFiles(caseFolderPath);
+              const pdfName = pdfPath ? pdfPath.split(/[/\\]/).pop() || '' : '';
+              const existingFolder = files.find(
+                (file: any) =>
+                  file.isFolder &&
+                  file.parentPdfName &&
+                  file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+              );
+              
+              if (existingFolder) {
+                existingFolderPath = existingFolder.path;
+                targetFolderName = existingFolder.name;
+              }
+            } catch (error) {
+              console.error('Error checking for existing folder:', error);
+            }
+
+            // Create folder if it doesn't exist
+            if (!existingFolderPath) {
+              if (!saveOptions.folderName || !saveOptions.folderName.trim()) {
+                throw new Error('Folder name is required');
+              }
+              await window.electronAPI.createExtractionFolder(
+                caseFolderPath,
+                saveOptions.folderName.trim(),
+                pdfPath || undefined
+              );
+              targetFolderName = saveOptions.folderName.trim();
+            }
+            break;
+          }
+
+          case 'add-to-pdf-folder': {
+            // Find existing folder and use it
+            const pdfName = pdfPath ? pdfPath.split(/[/\\]/).pop() || '' : '';
+            const files = await window.electronAPI.listCaseFiles(caseFolderPath);
+            const existingFolder = files.find(
+              (file: any) =>
+                file.isFolder &&
+                file.parentPdfName &&
+                file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+            );
+
+            if (!existingFolder) {
+              throw new Error('No existing folder found for this PDF');
+            }
+
+            targetFolderName = existingFolder.name;
+            break;
+          }
+
+          case 'add-folder-to-directory': {
+            // Find existing folder and create subfolder
+            const pdfName = pdfPath ? pdfPath.split(/[/\\]/).pop() || '' : '';
+            const files = await window.electronAPI.listCaseFiles(caseFolderPath);
+            const existingFolderForSubfolder = files.find(
+              (file: any) =>
+                file.isFolder &&
+                file.parentPdfName &&
+                file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+            );
+
+            if (!existingFolderForSubfolder) {
+              throw new Error('No existing folder found for this PDF');
+            }
+
+            if (!saveOptions.subfolderName || !saveOptions.subfolderName.trim()) {
+              throw new Error('Subfolder name is required');
+            }
+
+            // Store existing folder path for later use
+            subfolderPath = existingFolderForSubfolder.path;
+            targetFolderName = saveOptions.subfolderName.trim();
+            break;
+          }
+
+          default:
+            throw new Error('Invalid save option');
+        }
+
+        // Handle different save scenarios
+        if (saveOptions.saveOption === 'add-folder-to-directory' && subfolderPath) {
+          // Use saveFiles API with existing folder as base directory
+          // The folderName parameter will create the subfolder inside the saveDirectory
+          await window.electronAPI.saveFiles({
+            saveDirectory: subfolderPath, // Use existing folder path as base
+            saveParentFile: saveOptions.saveParentFile,
+            saveToZip: saveOptions.saveToZip,
+            folderName: saveOptions.subfolderName!.trim(), // This creates the subfolder inside saveDirectory
+            parentFilePath: pdfPath!,
+            extractedPages: pagesWithNames.map((p) => ({
+              pageNumber: p.pageNumber,
+              imageData: p.imageData,
+              fileName: p.fileName,
+            })),
+          });
+        } else if (saveOptions.saveOption === 'save-loose') {
+          // Save loose files - saveFiles will create the subfolder
+          // If createNewFolderForLoose is true, use the provided folder name
+          // If false, use default folder name
+          await window.electronAPI.saveFiles({
+            saveDirectory: caseFolderPath, // Base directory (case folder)
+            saveParentFile: saveOptions.saveParentFile,
+            saveToZip: saveOptions.saveToZip,
+            folderName: targetFolderName, // saveFiles will create this subfolder
+            parentFilePath: pdfPath!,
+            extractedPages: pagesWithNames.map((p) => ({
+              pageNumber: p.pageNumber,
+              imageData: p.imageData,
+              fileName: p.fileName,
+            })),
+          });
+        } else {
+          // Use extractPDFFromArchive for extraction folders (make-pdf-folder, add-to-pdf-folder)
+          await window.electronAPI.extractPDFFromArchive({
+            pdfPath: pdfPath!,
+            casePath: caseFolderPath,
+            folderName: targetFolderName,
+            saveParentFile: saveOptions.saveParentFile,
+            saveToZip: saveOptions.saveToZip,
+            extractedPages: pagesWithNames.map((p) => ({
+              pageNumber: p.pageNumber,
+              imageData: p.imageData,
+              fileName: p.fileName,
+            })),
+          });
+        }
+
         toast.success(`Saved ${pagesToSave.length} page${pagesToSave.length !== 1 ? 's' : ''} to archive`);
       } else {
         // Save to regular directory
@@ -734,6 +882,9 @@ export function PDFExtractionModal({
           onConfirm={handleSave}
           initialSaveDirectory={caseFolderPath || null}
           defaultFolderName={pdfPath ? pdfPath.split(/[/\\]/).pop()?.replace(/\.pdf$/i, '') : undefined}
+          pdfPath={pdfPath}
+          casePath={caseFolderPath || null}
+          existingFolders={existingFolders}
         />
       </motion.div>
     </AnimatePresence>

--- a/src/components/PDFExtractionSaveOptions.tsx
+++ b/src/components/PDFExtractionSaveOptions.tsx
@@ -380,6 +380,7 @@ export function PDFExtractionSaveOptions({
                                   setFolderNameError(null);
                                 }
                               }}
+                              onFocus={(e) => e.target.select()}
                               placeholder="Enter folder name..."
                               className={`w-full px-3 py-2 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
                                 folderNameError
@@ -452,6 +453,7 @@ export function PDFExtractionSaveOptions({
                                   setFolderNameError(null);
                                 }
                               }}
+                              onFocus={(e) => e.target.select()}
                               placeholder="Enter folder name..."
                               className={`w-full px-3 py-2 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
                                 folderNameError
@@ -617,6 +619,7 @@ export function PDFExtractionSaveOptions({
                       setFolderNameError(null);
                     }
                   }}
+                  onFocus={(e) => e.target.select()}
                   placeholder="Enter folder name..."
                   aria-required={!casePath}
                   className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${

--- a/src/components/PDFExtractionSaveOptions.tsx
+++ b/src/components/PDFExtractionSaveOptions.tsx
@@ -1,19 +1,28 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import { useState } from 'react';
-import { X, FolderOpen, Save, FileText } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { X, FolderOpen, Save, FileText, FolderPlus } from 'lucide-react';
+import { ArchiveFile } from '../types';
+
+export type ExtractionSaveOption = 'save-loose' | 'make-pdf-folder' | 'add-to-pdf-folder' | 'add-folder-to-directory';
 
 interface PDFExtractionSaveOptionsProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: (options: {
+    saveOption: ExtractionSaveOption;
     saveDirectory: string;
-    folderName: string;
+    folderName?: string;
+    subfolderName?: string;
+    createNewFolderForLoose?: boolean;
     saveParentFile: boolean;
     saveToZip: boolean;
     fileNamingPattern: string;
   }) => void;
   initialSaveDirectory?: string | null;
   defaultFolderName?: string;
+  pdfPath?: string | null;
+  casePath?: string | null;
+  existingFolders?: ArchiveFile[];
 }
 
 const NAMING_PATTERNS = [
@@ -23,13 +32,46 @@ const NAMING_PATTERNS = [
   { value: 'custom', label: 'Custom pattern' },
 ];
 
+// Helper function to find extraction folders for a PDF
+async function findExtractionFoldersForPDF(
+  pdfPath: string | null,
+  casePath: string | null
+): Promise<ArchiveFile[]> {
+  if (!pdfPath || !casePath || !window.electronAPI) {
+    return [];
+  }
+
+  try {
+    // Get PDF filename for matching
+    const pdfName = pdfPath.split(/[/\\]/).pop() || '';
+    
+    // List case files to find folders
+    const files = await window.electronAPI.listCaseFiles(casePath);
+    
+    // Filter for folders with matching parentPdfName
+    return files.filter(
+      (file: any) =>
+        file.isFolder &&
+        file.parentPdfName &&
+        file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+    ) as ArchiveFile[];
+  } catch (error) {
+    console.error('Failed to find extraction folders:', error);
+    return [];
+  }
+}
+
 export function PDFExtractionSaveOptions({
   isOpen,
   onClose,
   onConfirm,
   initialSaveDirectory,
   defaultFolderName,
+  pdfPath,
+  casePath,
+  existingFolders,
 }: PDFExtractionSaveOptionsProps) {
+  const [selectedOption, setSelectedOption] = useState<ExtractionSaveOption | null>(null);
   const [saveDirectory, setSaveDirectory] = useState<string>(initialSaveDirectory || '');
   const [folderName, setFolderName] = useState<string>(defaultFolderName || '');
   const [saveParentFile, setSaveParentFile] = useState(false);
@@ -37,6 +79,62 @@ export function PDFExtractionSaveOptions({
   const [fileNamingPattern, setFileNamingPattern] = useState('page-{n}');
   const [customPattern, setCustomPattern] = useState('');
   const [folderNameError, setFolderNameError] = useState<string | null>(null);
+  const [detectedFolders, setDetectedFolders] = useState<ArchiveFile[]>([]);
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [subfolderName, setSubfolderName] = useState('');
+  const [showSubfolderInput, setShowSubfolderInput] = useState(false);
+  const [createNewFolderForLoose, setCreateNewFolderForLoose] = useState(false);
+  const [looseFolderName, setLooseFolderName] = useState('');
+
+  // Detect existing folders on mount or when props change
+  useEffect(() => {
+    if (isOpen && pdfPath && casePath) {
+      setIsDetecting(true);
+      
+      // Use provided folders if available, otherwise detect
+      if (existingFolders && existingFolders.length > 0) {
+        setDetectedFolders(existingFolders);
+        setIsDetecting(false);
+      } else {
+        findExtractionFoldersForPDF(pdfPath, casePath)
+          .then((folders) => {
+            setDetectedFolders(folders);
+            setIsDetecting(false);
+          })
+          .catch((error) => {
+            console.error('Error detecting folders:', error);
+            setDetectedFolders([]);
+            setIsDetecting(false);
+          });
+      }
+    } else {
+      setDetectedFolders([]);
+    }
+  }, [isOpen, pdfPath, casePath, existingFolders]);
+
+  // Generate default folder name from PDF name
+  useEffect(() => {
+    if (pdfPath && !folderName) {
+      const pdfName = pdfPath.split(/[/\\]/).pop()?.replace(/\.pdf$/i, '') || 'extracted_images';
+      setFolderName(pdfName);
+    }
+  }, [pdfPath, folderName]);
+
+  // Auto-select option based on folder detection
+  useEffect(() => {
+    if (isOpen && !isDetecting) {
+      if (detectedFolders.length > 0 && !selectedOption) {
+        // Auto-select "Add to PDF Folder" if folder exists
+        setSelectedOption('add-to-pdf-folder');
+      } else if (detectedFolders.length === 0 && !selectedOption) {
+        // Auto-select "Make PDF Folder" if no folder exists
+        setSelectedOption('make-pdf-folder');
+      }
+    }
+  }, [isOpen, isDetecting, detectedFolders.length, selectedOption]);
+
+  const hasExistingFolder = detectedFolders.length > 0;
+  const firstExistingFolder = detectedFolders[0];
 
   const handleSelectDirectory = async () => {
     try {
@@ -52,13 +150,46 @@ export function PDFExtractionSaveOptions({
     }
   };
 
+  const handleOptionSelect = (option: ExtractionSaveOption) => {
+    setSelectedOption(option);
+    
+    if (option === 'add-folder-to-directory') {
+      setShowSubfolderInput(true);
+      setCreateNewFolderForLoose(false);
+    } else if (option === 'save-loose') {
+      setShowSubfolderInput(false);
+      // Don't reset createNewFolderForLoose - let user toggle it
+    } else {
+      setShowSubfolderInput(false);
+      setCreateNewFolderForLoose(false);
+    }
+  };
+
   const handleConfirm = () => {
+    if (!selectedOption) {
+      return;
+    }
+
+    if (!saveDirectory && casePath) {
+      // If we have a case path, use it as save directory
+      setSaveDirectory(casePath);
+    }
+
     if (!saveDirectory) {
       return;
     }
 
-    // Always validate folder name
-    if (!folderName.trim()) {
+    // Validate based on selected option
+    if (selectedOption === 'add-folder-to-directory' && !subfolderName.trim()) {
+      return; // Don't allow empty subfolder name
+    }
+
+    if (selectedOption === 'make-pdf-folder' && !folderName.trim()) {
+      setFolderNameError('Folder name is required');
+      return;
+    }
+
+    if (selectedOption === 'save-loose' && createNewFolderForLoose && !looseFolderName.trim()) {
       setFolderNameError('Folder name is required');
       return;
     }
@@ -66,12 +197,27 @@ export function PDFExtractionSaveOptions({
     const finalPattern = fileNamingPattern === 'custom' ? customPattern : fileNamingPattern;
 
     onConfirm({
+      saveOption: selectedOption,
       saveDirectory,
-      folderName: folderName.trim(),
+      folderName: selectedOption === 'make-pdf-folder' 
+        ? folderName.trim() 
+        : (selectedOption === 'save-loose' && createNewFolderForLoose ? looseFolderName.trim() : undefined),
+      subfolderName: selectedOption === 'add-folder-to-directory' ? subfolderName.trim() : undefined,
+      createNewFolderForLoose: selectedOption === 'save-loose' ? createNewFolderForLoose : false,
       saveParentFile,
       saveToZip,
       fileNamingPattern: finalPattern,
     });
+  };
+
+  const handleClose = () => {
+    setSelectedOption(null);
+    setSubfolderName('');
+    setShowSubfolderInput(false);
+    setCreateNewFolderForLoose(false);
+    setLooseFolderName('');
+    setFolderNameError(null);
+    onClose();
   };
 
   if (!isOpen) return null;
@@ -82,7 +228,7 @@ export function PDFExtractionSaveOptions({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        onClick={onClose}
+        onClick={handleClose}
         className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4"
         role="dialog"
         aria-modal="true"
@@ -115,7 +261,7 @@ export function PDFExtractionSaveOptions({
                 </div>
               </div>
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="p-2 hover:bg-gray-800 rounded-xl transition-colors"
                 aria-label="Close"
               >
@@ -126,28 +272,369 @@ export function PDFExtractionSaveOptions({
 
           {/* Content */}
           <div className="flex-1 overflow-y-auto p-6 space-y-6">
-            {/* Save Directory */}
-            <div>
-              <label className="block text-sm font-semibold text-gray-400 mb-3">
-                Save Directory
-              </label>
-              <div className="flex gap-3">
+            {/* Folder Location Options - Only show if we have casePath and pdfPath */}
+            {casePath && pdfPath && (
+              <div className="space-y-4">
+                <label className="block text-sm font-semibold text-gray-400 mb-3">
+                  Folder Location
+                </label>
+
+                {isDetecting ? (
+                  <div className="flex items-center justify-center py-4">
+                    <div className="text-gray-400">Detecting existing folders...</div>
+                  </div>
+                ) : (
+                  <>
+                    {/* Save Loose Option */}
+                    <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                      <div className="relative">
+                        <input
+                          type="radio"
+                          name="save-option"
+                          value="save-loose"
+                          checked={selectedOption === 'save-loose'}
+                          onChange={() => handleOptionSelect('save-loose')}
+                          className="sr-only"
+                        />
+                        <div
+                          className={`w-5 h-5 rounded-full border-2 transition-all ${
+                            selectedOption === 'save-loose'
+                              ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                              : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                          }`}
+                        >
+                          {selectedOption === 'save-loose' && (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              className="w-full h-full flex items-center justify-center"
+                            >
+                              <div className="w-2 h-2 rounded-full bg-white" />
+                            </motion.div>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <FileText className="w-4 h-4 text-gray-400" />
+                          <span className="text-sm font-medium text-gray-200">Save Loose</span>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                          Save to case folder (uses default folder name if no custom folder is created)
+                        </p>
+                      </div>
+                    </label>
+
+                    {/* Create New Folder option - expands when Save Loose is selected */}
+                    {selectedOption === 'save-loose' && (
+                      <div className="ml-8 pl-4 border-l-2 border-cyber-purple-400/30 space-y-3">
+                        <label className="flex items-center gap-3 p-3 bg-gray-800/30 rounded-lg border border-gray-700/30 cursor-pointer hover:bg-gray-800/50 transition-colors group">
+                          <div className="relative">
+                            <input
+                              type="checkbox"
+                              checked={createNewFolderForLoose}
+                              onChange={(e) => {
+                                setCreateNewFolderForLoose(e.target.checked);
+                                if (!e.target.checked) {
+                                  setLooseFolderName('');
+                                  setFolderNameError(null);
+                                }
+                              }}
+                              className="sr-only"
+                            />
+                            <div
+                              className={`w-4 h-4 rounded border-2 transition-all ${
+                                createNewFolderForLoose
+                                  ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                                  : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                              }`}
+                            >
+                              {createNewFolderForLoose && (
+                                <motion.div
+                                  initial={{ scale: 0 }}
+                                  animate={{ scale: 1 }}
+                                  className="w-full h-full flex items-center justify-center"
+                                >
+                                  <div className="w-1.5 h-1.5 rounded-full bg-white" />
+                                </motion.div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex-1">
+                            <span className="text-sm font-medium text-gray-300">Create New Folder inside case file</span>
+                          </div>
+                        </label>
+
+                        {/* Folder Name Input (shown when Create New Folder is checked) */}
+                        {createNewFolderForLoose && (
+                          <div>
+                            <label className="block text-xs font-semibold text-gray-400 mb-2">
+                              Folder Name
+                            </label>
+                            <input
+                              type="text"
+                              value={looseFolderName}
+                              onChange={(e) => {
+                                setLooseFolderName(e.target.value);
+                                if (folderNameError) {
+                                  setFolderNameError(null);
+                                }
+                              }}
+                              placeholder="Enter folder name..."
+                              className={`w-full px-3 py-2 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                                folderNameError
+                                  ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                                  : 'border-gray-700 focus:ring-cyber-purple-400'
+                              }`}
+                            />
+                            {folderNameError && (
+                              <p className="text-red-400 text-xs mt-2">{folderNameError}</p>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Make PDF Folder Option - Only show if no existing folder */}
+                    {!hasExistingFolder && (
+                      <>
+                        <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                          <div className="relative">
+                            <input
+                              type="radio"
+                              name="save-option"
+                              value="make-pdf-folder"
+                              checked={selectedOption === 'make-pdf-folder'}
+                              onChange={() => handleOptionSelect('make-pdf-folder')}
+                              className="sr-only"
+                            />
+                            <div
+                              className={`w-5 h-5 rounded-full border-2 transition-all ${
+                                selectedOption === 'make-pdf-folder'
+                                  ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                                  : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                              }`}
+                            >
+                              {selectedOption === 'make-pdf-folder' && (
+                                <motion.div
+                                  initial={{ scale: 0 }}
+                                  animate={{ scale: 1 }}
+                                  className="w-full h-full flex items-center justify-center"
+                                >
+                                  <div className="w-2 h-2 rounded-full bg-white" />
+                                </motion.div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                              <FolderPlus className="w-4 h-4 text-gray-400" />
+                              <span className="text-sm font-medium text-gray-200">Make PDF Folder</span>
+                            </div>
+                            <p className="text-xs text-gray-500 mt-1">
+                              Create folder above PDF (like Convert to Images)
+                            </p>
+                          </div>
+                        </label>
+
+                        {/* Folder Name Input (shown when Make PDF Folder is selected) */}
+                        {selectedOption === 'make-pdf-folder' && (
+                          <div className="ml-8 pl-4 border-l-2 border-cyber-purple-400/30">
+                            <label className="block text-xs font-semibold text-gray-400 mb-2">
+                              Folder Name
+                            </label>
+                            <input
+                              type="text"
+                              value={folderName}
+                              onChange={(e) => {
+                                setFolderName(e.target.value);
+                                if (folderNameError) {
+                                  setFolderNameError(null);
+                                }
+                              }}
+                              placeholder="Enter folder name..."
+                              className={`w-full px-3 py-2 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                                folderNameError
+                                  ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                                  : 'border-gray-700 focus:ring-cyber-purple-400'
+                              }`}
+                            />
+                            {folderNameError && (
+                              <p className="text-red-400 text-xs mt-2">{folderNameError}</p>
+                            )}
+                          </div>
+                        )}
+                      </>
+                    )}
+
+                    {/* Additional options when folder exists */}
+                    {hasExistingFolder && (
+                      <>
+                        {/* Add to PDF Folder Option */}
+                        <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                          <div className="relative">
+                            <input
+                              type="radio"
+                              name="save-option"
+                              value="add-to-pdf-folder"
+                              checked={selectedOption === 'add-to-pdf-folder'}
+                              onChange={() => handleOptionSelect('add-to-pdf-folder')}
+                              className="sr-only"
+                            />
+                            <div
+                              className={`w-5 h-5 rounded-full border-2 transition-all ${
+                                selectedOption === 'add-to-pdf-folder'
+                                  ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                                  : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                              }`}
+                            >
+                              {selectedOption === 'add-to-pdf-folder' && (
+                                <motion.div
+                                  initial={{ scale: 0 }}
+                                  animate={{ scale: 1 }}
+                                  className="w-full h-full flex items-center justify-center"
+                                >
+                                  <div className="w-2 h-2 rounded-full bg-white" />
+                                </motion.div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                              <FolderOpen className="w-4 h-4 text-gray-400" />
+                              <span className="text-sm font-medium text-gray-200">
+                                Add to PDF Folder
+                              </span>
+                              <span className="text-xs text-gray-500">({firstExistingFolder.name})</span>
+                            </div>
+                            <p className="text-xs text-gray-500 mt-1">
+                              Save to existing folder: {firstExistingFolder.name}
+                            </p>
+                          </div>
+                        </label>
+
+                        {/* Add Folder to Directory Option */}
+                        <label className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 cursor-pointer hover:bg-gray-800/70 transition-colors group">
+                          <div className="relative">
+                            <input
+                              type="radio"
+                              name="save-option"
+                              value="add-folder-to-directory"
+                              checked={selectedOption === 'add-folder-to-directory'}
+                              onChange={() => handleOptionSelect('add-folder-to-directory')}
+                              className="sr-only"
+                            />
+                            <div
+                              className={`w-5 h-5 rounded-full border-2 transition-all ${
+                                selectedOption === 'add-folder-to-directory'
+                                  ? 'bg-cyber-purple-400 border-cyber-purple-400'
+                                  : 'bg-transparent border-gray-500 group-hover:border-cyber-purple-400'
+                              }`}
+                            >
+                              {selectedOption === 'add-folder-to-directory' && (
+                                <motion.div
+                                  initial={{ scale: 0 }}
+                                  animate={{ scale: 1 }}
+                                  className="w-full h-full flex items-center justify-center"
+                                >
+                                  <div className="w-2 h-2 rounded-full bg-white" />
+                                </motion.div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                              <FolderPlus className="w-4 h-4 text-gray-400" />
+                              <span className="text-sm font-medium text-gray-200">
+                                Make Subfolder Within PDF Folder
+                              </span>
+                            </div>
+                            <p className="text-xs text-gray-500 mt-1">
+                              Create subfolder inside {firstExistingFolder.name}
+                            </p>
+                          </div>
+                        </label>
+
+                        {/* Subfolder Name Input (shown when Add Folder to Directory is selected) */}
+                        {showSubfolderInput && (
+                          <div className="ml-8 pl-4 border-l-2 border-cyber-purple-400/30">
+                            <label className="block text-xs font-semibold text-gray-400 mb-2">
+                              Subfolder Name
+                            </label>
+                            <input
+                              type="text"
+                              value={subfolderName}
+                              onChange={(e) => setSubfolderName(e.target.value)}
+                              placeholder="Enter subfolder name (e.g., Images)..."
+                              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
+                            />
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Save Directory - Only show if not using case folder options */}
+            {(!casePath || !pdfPath) && (
+              <div>
+                <label className="block text-sm font-semibold text-gray-400 mb-3">
+                  Save Directory
+                </label>
+                <div className="flex gap-3">
+                  <input
+                    type="text"
+                    value={saveDirectory}
+                    readOnly
+                    className="flex-1 px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
+                    placeholder="No directory selected"
+                  />
+                  <button
+                    onClick={handleSelectDirectory}
+                    className="px-6 py-3 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 rounded-lg font-medium text-white transition-all flex items-center gap-2"
+                  >
+                    <FolderOpen className="w-5 h-5" />
+                    Browse
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Folder Name - Only show if not using case folder options or if making new folder */}
+            {(!casePath || !pdfPath || selectedOption === 'make-pdf-folder') && selectedOption !== 'add-to-pdf-folder' && selectedOption !== 'add-folder-to-directory' && (
+              <div>
+                <label className="block text-sm font-semibold text-gray-400 mb-3">
+                  Folder Name {!casePath && <span className="text-red-400">*</span>}
+                </label>
                 <input
                   type="text"
-                  value={saveDirectory}
-                  readOnly
-                  className="flex-1 px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:ring-2 focus:ring-cyber-purple-400 focus:border-transparent"
-                  placeholder="No directory selected"
+                  value={folderName}
+                  onChange={(e) => {
+                    setFolderName(e.target.value);
+                    if (folderNameError) {
+                      setFolderNameError(null);
+                    }
+                  }}
+                  placeholder="Enter folder name..."
+                  aria-required={!casePath}
+                  className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
+                    folderNameError
+                      ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
+                      : 'border-gray-700 focus:ring-cyber-purple-400'
+                  }`}
                 />
-                <button
-                  onClick={handleSelectDirectory}
-                  className="px-6 py-3 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 rounded-lg font-medium text-white transition-all flex items-center gap-2"
-                >
-                  <FolderOpen className="w-5 h-5" />
-                  Browse
-                </button>
+                {folderNameError && (
+                  <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
+                )}
+                <p className="text-xs text-gray-500 mt-2">
+                  {saveToZip
+                    ? 'This name will be used for the ZIP file'
+                    : 'A subfolder with this name will be created to store the extracted images'}
+                </p>
               </div>
-            </div>
+            )}
 
             {/* Save Options */}
             <div className="space-y-4">
@@ -194,38 +681,6 @@ export function PDFExtractionSaveOptions({
               </label>
             </div>
 
-            {/* Folder Name */}
-            <div>
-              <label className="block text-sm font-semibold text-gray-400 mb-3">
-                Folder Name <span className="text-red-400">*</span>
-              </label>
-              <input
-                type="text"
-                value={folderName}
-                onChange={(e) => {
-                  setFolderName(e.target.value);
-                  if (folderNameError) {
-                    setFolderNameError(null);
-                  }
-                }}
-                placeholder="Enter folder name..."
-                aria-required="true"
-                className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white text-sm focus:ring-2 focus:border-transparent ${
-                  folderNameError
-                    ? 'border-red-500 focus:ring-red-500/20 focus:border-red-500'
-                    : 'border-gray-700 focus:ring-cyber-purple-400'
-                }`}
-              />
-              {folderNameError && (
-                <p className="text-red-400 text-sm mt-2">{folderNameError}</p>
-              )}
-              <p className="text-xs text-gray-500 mt-2">
-                {saveToZip
-                  ? 'This name will be used for the ZIP file'
-                  : 'A subfolder with this name will be created to store the extracted images'}
-              </p>
-            </div>
-
             {/* File Naming Pattern */}
             <div>
               <label className="block text-sm font-semibold text-gray-400 mb-3">
@@ -258,14 +713,21 @@ export function PDFExtractionSaveOptions({
           {/* Footer */}
           <div className="p-6 border-t border-cyber-purple-400/30 bg-gray-900/50 flex items-center justify-end gap-3">
             <button
-              onClick={onClose}
+              onClick={handleClose}
               className="px-6 py-2.5 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium transition-colors"
             >
               Cancel
             </button>
             <button
               onClick={handleConfirm}
-              disabled={!saveDirectory || !folderName.trim()}
+              disabled={
+                !selectedOption ||
+                (!casePath && !saveDirectory) ||
+                (selectedOption === 'add-folder-to-directory' && !subfolderName.trim()) ||
+                (selectedOption === 'make-pdf-folder' && !folderName.trim()) ||
+                (selectedOption === 'save-loose' && createNewFolderForLoose && !looseFolderName.trim()) ||
+                (!casePath && !folderName.trim())
+              }
               className="px-6 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 text-white rounded-lg font-medium transition-all disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Save className="w-4 h-4" />

--- a/src/components/SecurityCheckerModal.tsx
+++ b/src/components/SecurityCheckerModal.tsx
@@ -5,6 +5,9 @@ import { Shield, X, FileText, AlertTriangle, CheckCircle, Loader2, Upload, Setti
 import { useRedactionAudit, RedactionAuditResult } from '../hooks/useRedactionAudit';
 import { useToast } from './Toast/ToastContext';
 import { CaseSelectionDialog } from './Archive/CaseSelectionDialog';
+import { AuditSaveOptionsDialog, AuditSaveOption } from './AuditSaveOptionsDialog';
+
+import { ArchiveFile } from '../types';
 
 interface SecurityCheckerModalProps {
   isOpen: boolean;
@@ -12,9 +15,10 @@ interface SecurityCheckerModalProps {
   initialPdfPath?: string | null;
   caseFolderPath?: string | null;
   onReportSaved?: () => void;
+  existingFolders?: ArchiveFile[];
 }
 
-export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFolderPath, onReportSaved }: SecurityCheckerModalProps) {
+export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFolderPath, onReportSaved, existingFolders }: SecurityCheckerModalProps) {
   const [pdfPath, setPdfPath] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [settings, setSettings] = useState({
@@ -27,6 +31,7 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
   const toast = useToast();
   const [isGeneratingReport, setIsGeneratingReport] = useState(false);
   const [showCaseSelectionDialog, setShowCaseSelectionDialog] = useState(false);
+  const [showAuditSaveDialog, setShowAuditSaveDialog] = useState(false);
 
   const handleSelectFile = async () => {
     try {
@@ -290,8 +295,21 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
       return;
     }
 
+    // Show save options dialog instead of directly saving
+    setShowAuditSaveDialog(true);
+  };
+
+  const handleAuditSaveConfirm = async (
+    option: AuditSaveOption,
+    folderName?: string,
+    subfolderName?: string,
+    createNewFolderForLoose?: boolean,
+    looseFolderName?: string
+  ) => {
+    if (!result || !window.electronAPI || !caseFolderPath) return;
+
     setIsGeneratingReport(true);
-    const toastId = toast.info('Saving report to case folder...', 0);
+    const toastId = toast.info('Saving report...', 0);
 
     try {
       // Format audit result for report generation
@@ -300,17 +318,119 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
       // Generate filename
       const reportFilename = generateReportFilename(result.filename);
 
-      // Construct full path (use / as separator, main process will handle it)
-      const reportPath = `${targetCasePath}/${reportFilename}`;
+      let reportPath: string;
+
+      switch (option) {
+        case 'save-loose': {
+          // If createNewFolderForLoose is true, create a regular folder first
+          if (createNewFolderForLoose && looseFolderName && looseFolderName.trim()) {
+            // Create a regular folder (not an extraction folder, so no .parent-pdf metadata)
+            const createdFolderPath = await window.electronAPI.createFolder(
+              caseFolderPath,
+              looseFolderName.trim()
+            );
+            reportPath = `${createdFolderPath}/${reportFilename}`;
+          } else {
+            // Save directly to case folder (no subfolder)
+            reportPath = `${caseFolderPath}/${reportFilename}`;
+          }
+          break;
+        }
+
+        case 'make-pdf-folder': {
+          // Check if folder already exists by finding folders with matching parentPdfName
+          const pdfName = pdfPath ? pdfPath.split(/[/\\]/).pop() || '' : '';
+          
+          // Try to find existing folder
+          let targetFolderPath: string | null = null;
+          try {
+            const files = await window.electronAPI.listCaseFiles(caseFolderPath);
+            const existingFolder = files.find(
+              (file: any) =>
+                file.isFolder &&
+                file.parentPdfName &&
+                file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+            );
+            
+            if (existingFolder) {
+              targetFolderPath = existingFolder.path;
+            }
+          } catch (error) {
+            console.error('Error checking for existing folder:', error);
+          }
+
+          // Create folder if it doesn't exist
+          if (!targetFolderPath) {
+            if (!folderName || !folderName.trim()) {
+              throw new Error('Folder name is required');
+            }
+            targetFolderPath = await window.electronAPI.createExtractionFolder(
+              caseFolderPath,
+              folderName.trim(),
+              pdfPath || undefined
+            );
+          }
+
+          reportPath = `${targetFolderPath}/${reportFilename}`;
+          break;
+        }
+
+        case 'add-to-pdf-folder': {
+          // Find existing folder
+          const pdfName = pdfPath ? pdfPath.split(/[/\\]/).pop() || '' : '';
+          const files = await window.electronAPI.listCaseFiles(caseFolderPath);
+          const existingFolder = files.find(
+            (file: any) =>
+              file.isFolder &&
+              file.parentPdfName &&
+              file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+          );
+
+          if (!existingFolder) {
+            throw new Error('No existing folder found for this PDF');
+          }
+
+          reportPath = `${existingFolder.path}/${reportFilename}`;
+          break;
+        }
+
+        case 'add-folder-to-directory': {
+          // Find existing folder and create subfolder
+          const pdfName = pdfPath ? pdfPath.split(/[/\\]/).pop() || '' : '';
+          const files = await window.electronAPI.listCaseFiles(caseFolderPath);
+          const existingFolder = files.find(
+            (file: any) =>
+              file.isFolder &&
+              file.parentPdfName &&
+              file.parentPdfName.toLowerCase() === pdfName.toLowerCase()
+          );
+
+          if (!existingFolder) {
+            throw new Error('No existing folder found for this PDF');
+          }
+
+          if (!subfolderName || !subfolderName.trim()) {
+            throw new Error('Subfolder name is required');
+          }
+
+          // Construct subfolder path - use forward slashes, main process will normalize
+          // The generateAuditReport Python script will create the directory if it doesn't exist
+          reportPath = `${existingFolder.path}/${subfolderName.trim()}/${reportFilename}`;
+          break;
+        }
+
+        default:
+          throw new Error('Invalid save option');
+      }
 
       toast.updateToast(toastId, 'Generating PDF report...', 'info');
 
-      // Generate report directly to case folder
+      // Generate report to the determined path
       const reportResult = await window.electronAPI.generateAuditReport(auditResult, reportPath);
 
       if (reportResult.success) {
         toast.dismissToast(toastId);
-        toast.success('Report saved to case folder!', 3000);
+        toast.success('Report saved successfully!', 3000);
         
         // Notify parent component that report was saved (for refreshing file list)
         if (onReportSaved) {
@@ -579,17 +699,17 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
                             <button
                               onClick={() => handleSaveToCaseFolder()}
                               disabled={isGeneratingReport}
-                              className="px-5 py-2.5 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 rounded-xl font-bold text-white transition-all disabled:cursor-not-allowed flex items-center gap-2 shadow-lg hover:shadow-xl text-sm"
+                              className="px-4 py-2 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 disabled:from-gray-700 disabled:to-gray-700 rounded-xl font-bold text-white transition-all disabled:cursor-not-allowed flex items-center gap-2 shadow-lg hover:shadow-xl text-xs"
                               title={caseFolderPath ? "Save report to current case folder" : "Save report to a case"}
                             >
                               {isGeneratingReport ? (
                                 <>
-                                  <Loader2 className="w-4 h-4 animate-spin" />
+                                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
                                   <span>Generating...</span>
                                 </>
                               ) : (
                                 <>
-                                  <FolderOpen className="w-4 h-4" />
+                                  <FolderOpen className="w-3.5 h-3.5" />
                                   <span>{caseFolderPath ? 'Save to Current Case' : 'Save to Case'}</span>
                                 </>
                               )}
@@ -597,16 +717,16 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
                             <button
                               onClick={handleDownloadReport}
                               disabled={isGeneratingReport}
-                              className="px-5 py-2.5 bg-gradient-to-r from-cyan-600 to-purple-600 hover:from-cyan-700 hover:to-purple-700 disabled:from-gray-700 disabled:to-gray-700 rounded-xl font-bold text-white transition-all disabled:cursor-not-allowed flex items-center gap-2 shadow-lg hover:shadow-xl text-sm"
+                              className="px-4 py-2 bg-gradient-to-r from-cyan-600 to-purple-600 hover:from-cyan-700 hover:to-purple-700 disabled:from-gray-700 disabled:to-gray-700 rounded-xl font-bold text-white transition-all disabled:cursor-not-allowed flex items-center gap-2 shadow-lg hover:shadow-xl text-xs"
                             >
                               {isGeneratingReport ? (
                                 <>
-                                  <Loader2 className="w-4 h-4 animate-spin" />
+                                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
                                   <span>Generating...</span>
                                 </>
                               ) : (
                                 <>
-                                  <Download className="w-4 h-4" />
+                                  <Download className="w-3.5 h-3.5" />
                                   <span>Download Report</span>
                                 </>
                               )}
@@ -1048,6 +1168,16 @@ export function SecurityCheckerModal({ isOpen, onClose, initialPdfPath, caseFold
           onSelectCase={handleCaseSelected}
         />
       )}
+
+      {/* Audit Save Options Dialog */}
+      <AuditSaveOptionsDialog
+        isOpen={showAuditSaveDialog}
+        onClose={() => setShowAuditSaveDialog(false)}
+        onConfirm={handleAuditSaveConfirm}
+        pdfPath={pdfPath}
+        casePath={caseFolderPath || null}
+        existingFolders={existingFolders}
+      />
     </AnimatePresence>
   );
 }

--- a/src/components/WordEditor/WordEditorPanel.tsx
+++ b/src/components/WordEditor/WordEditorPanel.tsx
@@ -86,7 +86,23 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
   useEffect(() => {
     const handleReattach = (event: CustomEvent<{ content: string; filePath?: string | null; viewState?: 'editor' | 'library' | 'bookmarkLibrary'; casePath?: string | null }>) => {
       const data = event.detail;
-      // Set the file path if provided
+      
+      // Ensure panel is open when reattaching
+      if (!isOpen) {
+        // Open the panel first
+        setContextOpen(true);
+        // Wait a bit for the panel to open before proceeding
+        setTimeout(() => {
+          handleReattachContent(data);
+        }, 100);
+      } else {
+        handleReattachContent(data);
+      }
+    };
+
+    const handleReattachContent = (data: { content: string; filePath?: string | null; viewState?: 'editor' | 'library' | 'bookmarkLibrary'; casePath?: string | null }) => {
+      // Set the file path FIRST (but this will trigger loadFile)
+      // We'll prevent loadFile from overwriting by using word-editor-data event
       if (data.filePath) {
         setCurrentFilePath(data.filePath);
       } else {
@@ -121,22 +137,48 @@ export function WordEditorPanel({ isOpen, onClose, initialFilePath, openLibrary,
       // Force re-render to ensure editor is ready
       setEditorKey(prev => prev + 1);
 
-      // Set content after a short delay to ensure editor is ready
-      // Use setTimeout to allow the editor to initialize first
+      // Use word-editor-data event to set content (this bypasses file loading)
+      // This event is handled by WordEditor and sets content without triggering loadFile
       setTimeout(() => {
-        if (editorRef.current && data.content) {
-          editorRef.current.setContent(data.content);
-          // Mark as saved since it was just saved before reattaching
-          editorRef.current.markAsSaved();
-        }
-      }, 100);
+        const contentEvent = new CustomEvent('word-editor-data', {
+          detail: {
+            content: data.content,
+            filePath: data.filePath,
+          }
+        });
+        window.dispatchEvent(contentEvent);
+
+        // Also set via ref after a delay to ensure it's set
+        const setContentWithRetry = (attempt = 0) => {
+          const maxAttempts = 10;
+          const delay = 100 + (attempt * 100); // 100ms, 200ms, 300ms, etc.
+
+          setTimeout(() => {
+            if (editorRef.current && data.content) {
+              try {
+                editorRef.current.setContent(data.content);
+                editorRef.current.markAsSaved();
+              } catch (error) {
+                console.error('Failed to set content on reattach via ref:', error);
+                if (attempt < maxAttempts) {
+                  setContentWithRetry(attempt + 1);
+                }
+              }
+            } else if (attempt < maxAttempts) {
+              setContentWithRetry(attempt + 1);
+            }
+          }, delay);
+        };
+
+        setContentWithRetry();
+      }, 150);
     };
 
     window.addEventListener('reattach-word-editor-data' as any, handleReattach as EventListener);
     return () => {
       window.removeEventListener('reattach-word-editor-data' as any, handleReattach as EventListener);
     };
-  }, []);
+  }, [isOpen, currentCase, setContextOpen]);
 
   const handleDetach = async () => {
     try {


### PR DESCRIPTION
## Description

This PR enhances the save options for PDF extraction and audit reports, and fixes a critical bug where word editor content wasn't being restored when reattaching from a detached window.

## Type of Change

- [x] Bug fix (word editor reattach content restoration)
- [x] New feature (Save Loose with Create New Folder option)
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### PDF Extraction & Audit Report Save Options

**New "Save Loose" Option with Nested "Create New Folder"**
- Added expandable "Create New Folder inside case file" checkbox under "Save Loose" option
- When checked, displays folder name input dialog
- When unchecked, saves directly to case folder (uses default folder name for PDF extraction)
- Creates regular folders (not extraction folders) when "Create New Folder" is selected
- Applied consistently to both PDF extraction and audit report saving flows

**Save Logic Improvements**
- Fixed `saveFiles` API integration to properly handle folder creation
- Updated save flow to prevent creating extraction folders that appear above PDFs
- Ensured proper folder name validation and error handling

### Word Editor Reattach Fix

**Content Restoration**
- Fixed critical bug where editor content was lost when reattaching from detached window
- Implemented dual approach: uses `word-editor-data` event to bypass file loading, plus ref-based fallback
- Added retry mechanism with increasing delays to ensure editor ref is ready before setting content
- Ensures panel opens automatically when reattaching from detached window

### Build Fixes

- Updated `DetachedPDFExtraction.handleSave` to match new save options signature
- Fixed `targetFolderName` initialization in `PDFExtractionModal` to prevent TypeScript errors
- Updated type definitions to include `createNewFolderForLoose` option

## Files Changed

- `src/components/PDFExtractionSaveOptions.tsx` - Added nested "Create New Folder" option
- `src/components/PDFExtractionModal.tsx` - Updated save logic for loose file saving
- `src/components/AuditSaveOptionsDialog.tsx` - Applied same save options pattern
- `src/components/SecurityCheckerModal.tsx` - Updated audit report save logic
- `src/components/DetachedPDFExtraction.tsx` - Fixed type signature and save logic
- `src/components/WordEditor/WordEditorPanel.tsx` - Fixed reattach content restoration

## Testing

- [x] Tests pass locally
- [x] Manual testing completed for:
  - [x] PDF extraction "Save Loose" with and without "Create New Folder"
  - [x] Audit report "Save Loose" with and without "Create New Folder"
  - [x] Word editor detach and reattach with content restoration
  - [x] New document creation, typing, saving, detaching, and reattaching
- [x] Verified no build errors
- [x] Verified TypeScript strict mode compliance

## User Impact

**Positive Changes:**
- Users can now save PDF extractions and audit reports directly to case folders or create custom folders
- Word editor content is now properly restored when reattaching from detached window
- More flexible save options for organizing extracted files and reports

**Breaking Changes:**
- None

## Screenshots/Notes

- The "Save Loose" option now expands to show "Create New Folder" checkbox when selected
- Folder name input appears when "Create New Folder" is checked
- Word editor content is preserved when detaching and reattaching windows

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
- [x] All tests pass
- [x] TypeScript strict mode satisfied
- [x] No `any` types used
- [x] Error handling implemented
- [x] User-facing error messages are clear

## Related Issues

N/A - Feature enhancement and bug fix

## Additional Notes

- The save logic now properly distinguishes between extraction folders (with `.parent-pdf` metadata) and regular folders
- Regular folders created via "Create New Folder" do not appear above PDFs in the archive view
- Word editor reattach now uses event-based content restoration to prevent file loading from overwriting restored content